### PR TITLE
Initial support for referencing dll libraries packaged within artifacts.

### DIFF
--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/JarUtil.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/JarUtil.java
@@ -1,0 +1,40 @@
+package org.codehaus.plexus.compiler.csharp;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class JarUtil {
+    public static void extract( File destDir, File jarFile ) throws IOException
+    {
+        JarFile jar = new JarFile( jarFile );
+        Enumeration enumEntries = jar.entries();
+        while ( enumEntries.hasMoreElements() ) {
+            JarEntry file = ( JarEntry ) enumEntries.nextElement();
+            File f = new File( destDir + File.separator + file.getName() );
+            if ( file.isDirectory() )
+            {
+                f.mkdir();
+                continue;
+            }
+            InputStream is = jar.getInputStream( file );
+            FileOutputStream fos = new FileOutputStream( f );
+            try
+            {
+                while ( is.available() > 0 )
+                {
+                    fos.write( is.read() );
+                }
+            }
+            finally
+            {
+                is.close();
+                fos.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello,

We added the following feature that allows us to unpack .net libraries contained within jars found at class path entries.

Please let us know if you consider it can be merged.

Thanks,

EthicLab.