### PR TITLE
Ignore source locations if they do not exist.

### DIFF
--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
@@ -547,6 +547,14 @@ Options can be of the form -option or /option
         {
             for ( String sourceLocation : config.getSourceLocations() )
             {
+                if (!new File(sourceLocation).exists())
+                {
+                    if ( config.isDebug() )
+                    {
+                        System.out.println( "Ignoring not found sourceLocation at: " + sourceLocation );
+                    }
+                    continue;
+                }
                 sources.addAll( getSourceFilesForSourceRoot( config, sourceLocation ) );
             }
         }


### PR DESCRIPTION
Hello,

We also found the following problem trying to execute mvn clean package on a simple project.

This hack tries to fix it. Please let us know if you think there is a better way to fix it.

`````
git clone https://github.com/ethiclab/example-csharp-maven-project-01
cd example-csharp-maven-project-01
mvn clean package
`````

output:
=====

`````
Apache Maven 3.2.1 (ea8b2b07643dbb1b84b6d16e1f08391b666bc1e9; 2014-02-14T18:37:52+01:00)
Maven home: /usr/local/Cellar/maven/3.2.1/libexec
Java version: 1.7.0_40-ea, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.10.3", arch: "x86_64", family: "mac"
[INFO] Error stacktraces are turned on.
[DEBUG] Reading global settings from /usr/local/Cellar/maven/3.2.1/libexec/conf/settings.xml
[DEBUG] Reading user settings from /Users/montoyaedu/.m2/settings.xml
[DEBUG] Using local repository at /Users/montoyaedu/.m2/repository
[DEBUG] Using manager EnhancedLocalRepositoryManager with priority 10.0 for /Users/montoyaedu/.m2/repository
[INFO] Scanning for projects...
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=2, ConflictMarker.markTime=1, ConflictMarker.nodeCount=147, ConflictIdSorter.graphTime=1, ConflictIdSorter.topsortTime=1, ConflictIdSorter.conflictIdCount=45, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=15, ConflictResolver.conflictItemCount=76, DefaultDependencyCollector.collectTime=429, DefaultDependencyCollector.transformTime=23}
[DEBUG] org.apache.maven.plugins:maven-compiler-plugin:jar:3.3:
[DEBUG]    org.codehaus.plexus:plexus-compiler-csharp:jar:2.5:runtime
[DEBUG]       org.codehaus.plexus:plexus-utils:jar:3.0.10:compile
[DEBUG]    org.apache.maven:maven-plugin-api:jar:2.2.1:compile
[DEBUG]    org.apache.maven:maven-artifact:jar:2.2.1:compile
[DEBUG]    org.apache.maven:maven-core:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-settings:jar:2.2.1:compile
[DEBUG]          org.codehaus.plexus:plexus-interpolation:jar:1.11:compile
[DEBUG]       org.apache.maven:maven-plugin-parameter-documenter:jar:2.2.1:compile
[DEBUG]       org.slf4j:slf4j-jdk14:jar:1.5.6:runtime
[DEBUG]          org.slf4j:slf4j-api:jar:1.5.6:runtime
[DEBUG]       org.slf4j:jcl-over-slf4j:jar:1.5.6:runtime
[DEBUG]       org.apache.maven:maven-profile:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-model:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-repository-metadata:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-error-diagnostics:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-project:jar:2.2.1:compile
[DEBUG]          org.apache.maven:maven-plugin-registry:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-plugin-descriptor:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
[DEBUG]          backport-util-concurrent:backport-util-concurrent:jar:3.1:compile
[DEBUG]       org.apache.maven:maven-monitor:jar:2.2.1:compile
[DEBUG]       org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
[DEBUG]          org.sonatype.plexus:plexus-cipher:jar:1.4:compile
[DEBUG]    org.apache.maven:maven-toolchain:jar:2.2.1:compile
[DEBUG]    org.apache.maven.shared:maven-shared-utils:jar:0.7:compile
[DEBUG]       com.google.code.findbugs:jsr305:jar:2.0.1:compile
[DEBUG]    org.apache.maven.shared:maven-shared-incremental:jar:1.1:compile
[DEBUG]       org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-api:jar:2.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-manager:jar:2.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-javac:jar:2.5:runtime
[DEBUG]    org.codehaus.plexus:plexus-container-default:jar:1.5.5:compile
[DEBUG]       org.codehaus.plexus:plexus-classworlds:jar:2.2.2:compile
[DEBUG]       org.apache.xbean:xbean-reflect:jar:3.4:compile
[DEBUG]          log4j:log4j:jar:1.2.12:compile
[DEBUG]          commons-logging:commons-logging-api:jar:1.1:compile
[DEBUG]       com.google.collections:google-collections:jar:1.0:compile
[DEBUG]       junit:junit:jar:3.8.2:compile
[DEBUG] Created new class realm maven.api
[DEBUG] Importing foreign packages into class realm maven.api
[DEBUG]   Imported: org.apache.maven.wagon.events < plexus.core
[DEBUG]   Imported: org.eclipse.aether.impl < plexus.core
[DEBUG]   Imported: org.apache.maven.exception < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.Xpp3Dom < plexus.core
[DEBUG]   Imported: org.eclipse.aether.version < plexus.core
[DEBUG]   Imported: org.eclipse.aether.metadata < plexus.core
[DEBUG]   Imported: org.eclipse.aether.collection < plexus.core
[DEBUG]   Imported: org.apache.maven.monitor < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.repository < plexus.core
[DEBUG]   Imported: org.apache.maven.repository < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.resource < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.logging < plexus.core
[DEBUG]   Imported: org.apache.maven.profiles < plexus.core
[DEBUG]   Imported: org.apache.maven.classrealm < plexus.core
[DEBUG]   Imported: org.apache.maven.execution.scope < plexus.core
[DEBUG]   Imported: org.eclipse.aether.artifact < plexus.core
[DEBUG]   Imported: org.apache.maven.execution < plexus.core
[DEBUG]   Imported: org.apache.maven.reporting < plexus.core
[DEBUG]   Imported: org.apache.maven.usability < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.container < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.component < plexus.core
[DEBUG]   Imported: org.eclipse.aether.transfer < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.authentication < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlSerializer < plexus.core
[DEBUG]   Imported: org.apache.maven.lifecycle < plexus.core
[DEBUG]   Imported: org.eclipse.aether.* < plexus.core
[DEBUG]   Imported: org.eclipse.aether.graph < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.classworlds < plexus.core
[DEBUG]   Imported: org.eclipse.aether.internal.impl < plexus.core
[DEBUG]   Imported: org.eclipse.aether.repository < plexus.core
[DEBUG]   Imported: org.eclipse.aether.resolution < plexus.core
[DEBUG]   Imported: javax.inject.* < plexus.core
[DEBUG]   Imported: org.apache.maven.settings < plexus.core
[DEBUG]   Imported: org.codehaus.classworlds < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.* < plexus.core
[DEBUG]   Imported: org.apache.maven.toolchain < plexus.core
[DEBUG]   Imported: org.eclipse.aether.spi < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.observers < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlPullParserException < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.util.xml.pull.XmlPullParser < plexus.core
[DEBUG]   Imported: org.apache.maven.configuration < plexus.core
[DEBUG]   Imported: org.apache.maven.cli < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.context < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.authorization < plexus.core
[DEBUG]   Imported: org.apache.maven.project < plexus.core
[DEBUG]   Imported: org.eclipse.aether.installation < plexus.core
[DEBUG]   Imported: org.eclipse.aether.deployment < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.lifecycle < plexus.core
[DEBUG]   Imported: org.apache.maven.rtinfo < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.configuration < plexus.core
[DEBUG]   Imported: org.apache.maven.artifact < plexus.core
[DEBUG]   Imported: org.apache.maven.model < plexus.core
[DEBUG]   Imported: org.slf4j.* < plexus.core
[DEBUG]   Imported: javax.enterprise.inject.* < plexus.core
[DEBUG]   Imported: org.apache.maven.* < plexus.core
[DEBUG]   Imported: org.apache.maven.wagon.proxy < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.* < plexus.core
[DEBUG]   Imported: org.apache.maven.plugin < plexus.core
[DEBUG]   Imported: org.codehaus.plexus.personality < plexus.core
[DEBUG] Populating class realm maven.api
[DEBUG] Created new class realm extension>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG] Importing foreign packages into class realm extension>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG]   Imported:  < maven.api
[DEBUG] Populating class realm extension>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG]   Included: org.apache.maven.plugins:maven-compiler-plugin:jar:3.3
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-csharp:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:3.0.10
[DEBUG]   Included: org.codehaus.plexus:plexus-interpolation:jar:1.11
[DEBUG]   Included: org.slf4j:slf4j-jdk14:jar:1.5.6
[DEBUG]   Included: org.slf4j:slf4j-api:jar:1.5.6
[DEBUG]   Included: org.slf4j:jcl-over-slf4j:jar:1.5.6
[DEBUG]   Included: backport-util-concurrent:backport-util-concurrent:jar:3.1
[DEBUG]   Included: org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3
[DEBUG]   Included: org.sonatype.plexus:plexus-cipher:jar:1.4
[DEBUG]   Included: org.apache.maven.shared:maven-shared-utils:jar:0.7
[DEBUG]   Included: com.google.code.findbugs:jsr305:jar:2.0.1
[DEBUG]   Included: org.apache.maven.shared:maven-shared-incremental:jar:1.1
[DEBUG]   Included: org.codehaus.plexus:plexus-component-annotations:jar:1.5.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-api:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-manager:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-javac:jar:2.5
[DEBUG]   Included: org.apache.xbean:xbean-reflect:jar:3.4
[DEBUG]   Included: log4j:log4j:jar:1.2.12
[DEBUG]   Included: commons-logging:commons-logging-api:jar:1.1
[DEBUG]   Included: com.google.collections:google-collections:jar:1.0
[DEBUG]   Included: junit:junit:jar:3.8.2
[DEBUG] Extension realms for project EthicLab.Samples:ExampleCSharpMavenProject01:jar:1.0.0.0-SNAPSHOT: [ClassRealm[extension>org.apache.maven.plugins:maven-compiler-plugin:3.3, parent: sun.misc.Launcher$AppClassLoader@3b76d662]]
[DEBUG] Created new class realm project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Populating class realm project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Looking up lifecyle mappings for packaging jar from ClassRealm[project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT, parent: ClassRealm[maven.api, parent: null]]
[DEBUG] === REACTOR BUILD PLAN ================================================
[DEBUG] Project: EthicLab.Samples:ExampleCSharpMavenProject01:jar:1.0.0.0-SNAPSHOT
[DEBUG] Tasks:   [clean, package]
[DEBUG] Style:   Regular
[DEBUG] =======================================================================
[INFO] 
[INFO] Using the builder org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder with a thread count of 1
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building ExampleCSharpMavenProject01 1.0.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] Lifecycle default -> [validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy]
[DEBUG] Lifecycle clean -> [pre-clean, clean, post-clean]
[DEBUG] Lifecycle site -> [pre-site, site, post-site, site-deploy]
[DEBUG] === PROJECT BUILD PLAN ================================================
[DEBUG] Project:       EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Dependencies (collect): []
[DEBUG] Dependencies (resolve): [compile, runtime, test]
[DEBUG] Repositories (dependencies): [central (http://repo.maven.apache.org/maven2, releases)]
[DEBUG] Repositories (plugins)     : [central (http://repo.maven.apache.org/maven2, releases)]
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-clean-plugin:2.5:clean (default-clean)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <directory default-value="${project.build.directory}"/>
  <excludeDefaultDirectories default-value="false">${clean.excludeDefaultDirectories}</excludeDefaultDirectories>
  <failOnError default-value="true">${maven.clean.failOnError}</failOnError>
  <followSymLinks default-value="false">${clean.followSymLinks}</followSymLinks>
  <outputDirectory default-value="${project.build.outputDirectory}"/>
  <reportDirectory default-value="${project.reporting.outputDirectory}"/>
  <retryOnError default-value="true">${maven.clean.retryOnError}</retryOnError>
  <skip default-value="false">${clean.skip}</skip>
  <testOutputDirectory default-value="${project.build.testOutputDirectory}"/>
  <verbose>${clean.verbose}</verbose>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-resources-plugin:2.6:resources (default-resources)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <buildFilters default-value="${project.build.filters}"/>
  <encoding default-value="${project.build.sourceEncoding}">${encoding}</encoding>
  <escapeString>${maven.resources.escapeString}</escapeString>
  <escapeWindowsPaths default-value="true">${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
  <includeEmptyDirs default-value="false">${maven.resources.includeEmptyDirs}</includeEmptyDirs>
  <outputDirectory default-value="${project.build.outputDirectory}"/>
  <overwrite default-value="false">${maven.resources.overwrite}</overwrite>
  <project default-value="${project}"/>
  <resources default-value="${project.resources}"/>
  <session default-value="${session}"/>
  <supportMultiLineFiltering default-value="false">${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
  <useBuildFilters default-value="true"/>
  <useDefaultDelimiters default-value="true"/>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <basedir default-value="${basedir}"/>
  <buildDirectory default-value="${project.build.directory}"/>
  <classpathElements default-value="${project.compileClasspathElements}"/>
  <compileSourceRoots default-value="${project.compileSourceRoots}"/>
  <compilerId default-value="javac">csharp</compilerId>
  <compilerReuseStrategy default-value="${reuseCreated}">${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
  <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
  <debug default-value="true">${maven.compiler.debug}</debug>
  <debuglevel>${maven.compiler.debuglevel}</debuglevel>
  <encoding default-value="${project.build.sourceEncoding}">${encoding}</encoding>
  <excludes>
    <exclude>target</exclude>
    <exclude>bin</exclude>
    <exclude>obj</exclude>
  </excludes>
  <executable>${maven.compiler.executable}</executable>
  <failOnError default-value="true">${maven.compiler.failOnError}</failOnError>
  <forceJavacCompilerUse default-value="false">${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
  <fork default-value="false">true</fork>
  <generatedSourcesDirectory default-value="${project.build.directory}/generated-sources/annotations"/>
  <maxmem>${maven.compiler.maxmem}</maxmem>
  <meminitial>${maven.compiler.meminitial}</meminitial>
  <mojoExecution default-value="${mojoExecution}"/>
  <optimize default-value="false">${maven.compiler.optimize}</optimize>
  <outputDirectory default-value="${project.build.outputDirectory}"/>
  <outputFileName>ExampleCSharpMavenProject01</outputFileName>
  <project default-value="${project}"/>
  <projectArtifact default-value="${project.artifact}"/>
  <session default-value="${session}"/>
  <showDeprecation default-value="false">${maven.compiler.showDeprecation}</showDeprecation>
  <showWarnings default-value="false">${maven.compiler.showWarnings}</showWarnings>
  <skipMain>${maven.main.skip}</skipMain>
  <skipMultiThreadWarning default-value="false">${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
  <source default-value="1.5">${maven.compiler.source}</source>
  <staleMillis default-value="0">${lastModGranularityMs}</staleMillis>
  <target default-value="1.5">${maven.compiler.target}</target>
  <useIncrementalCompilation default-value="true">${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
  <verbose default-value="false">${maven.compiler.verbose}</verbose>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-resources-plugin:2.6:testResources (default-testResources)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <buildFilters default-value="${project.build.filters}"/>
  <encoding default-value="${project.build.sourceEncoding}">${encoding}</encoding>
  <escapeString>${maven.resources.escapeString}</escapeString>
  <escapeWindowsPaths default-value="true">${maven.resources.escapeWindowsPaths}</escapeWindowsPaths>
  <includeEmptyDirs default-value="false">${maven.resources.includeEmptyDirs}</includeEmptyDirs>
  <outputDirectory default-value="${project.build.testOutputDirectory}"/>
  <overwrite default-value="false">${maven.resources.overwrite}</overwrite>
  <project default-value="${project}"/>
  <resources default-value="${project.testResources}"/>
  <session default-value="${session}"/>
  <skip>${maven.test.skip}</skip>
  <supportMultiLineFiltering default-value="false">${maven.resources.supportMultiLineFiltering}</supportMultiLineFiltering>
  <useBuildFilters default-value="true"/>
  <useDefaultDelimiters default-value="true"/>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-compiler-plugin:3.3:testCompile (default-testCompile)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <basedir default-value="${basedir}"/>
  <buildDirectory default-value="${project.build.directory}"/>
  <classpathElements default-value="${project.testClasspathElements}"/>
  <compileSourceRoots default-value="${project.testCompileSourceRoots}"/>
  <compilerId default-value="javac">csharp</compilerId>
  <compilerReuseStrategy default-value="${reuseCreated}">${maven.compiler.compilerReuseStrategy}</compilerReuseStrategy>
  <compilerVersion>${maven.compiler.compilerVersion}</compilerVersion>
  <debug default-value="true">${maven.compiler.debug}</debug>
  <debuglevel>${maven.compiler.debuglevel}</debuglevel>
  <encoding default-value="${project.build.sourceEncoding}">${encoding}</encoding>
  <executable>${maven.compiler.executable}</executable>
  <failOnError default-value="true">${maven.compiler.failOnError}</failOnError>
  <forceJavacCompilerUse default-value="false">${maven.compiler.forceJavacCompilerUse}</forceJavacCompilerUse>
  <fork default-value="false">true</fork>
  <generatedTestSourcesDirectory default-value="${project.build.directory}/generated-test-sources/test-annotations"/>
  <maxmem>${maven.compiler.maxmem}</maxmem>
  <meminitial>${maven.compiler.meminitial}</meminitial>
  <mojoExecution default-value="${mojoExecution}"/>
  <optimize default-value="false">${maven.compiler.optimize}</optimize>
  <outputDirectory default-value="${project.build.testOutputDirectory}"/>
  <outputFileName>ExampleCSharpMavenProject01</outputFileName>
  <project default-value="${project}"/>
  <session default-value="${session}"/>
  <showDeprecation default-value="false">${maven.compiler.showDeprecation}</showDeprecation>
  <showWarnings default-value="false">${maven.compiler.showWarnings}</showWarnings>
  <skip>${maven.test.skip}</skip>
  <skipMultiThreadWarning default-value="false">${maven.compiler.skipMultiThreadWarning}</skipMultiThreadWarning>
  <source default-value="1.5">${maven.compiler.source}</source>
  <staleMillis default-value="0">${lastModGranularityMs}</staleMillis>
  <target default-value="1.5">${maven.compiler.target}</target>
  <testSource>${maven.compiler.testSource}</testSource>
  <testTarget>${maven.compiler.testTarget}</testTarget>
  <useIncrementalCompilation default-value="true">${maven.compiler.useIncrementalCompilation}</useIncrementalCompilation>
  <verbose default-value="false">${maven.compiler.verbose}</verbose>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <argLine>${argLine}</argLine>
  <basedir default-value="${basedir}"/>
  <childDelegation default-value="false">${childDelegation}</childDelegation>
  <classesDirectory default-value="${project.build.outputDirectory}"/>
  <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
  <disableXmlReport default-value="false">${disableXmlReport}</disableXmlReport>
  <enableAssertions default-value="true">${enableAssertions}</enableAssertions>
  <excludedGroups>${excludedGroups}</excludedGroups>
  <failIfNoSpecifiedTests>${surefire.failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
  <failIfNoTests>${failIfNoTests}</failIfNoTests>
  <forkMode default-value="once">${forkMode}</forkMode>
  <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
  <groups>${groups}</groups>
  <junitArtifactName default-value="junit:junit">${junitArtifactName}</junitArtifactName>
  <jvm>${jvm}</jvm>
  <localRepository default-value="${localRepository}"/>
  <objectFactory>${objectFactory}</objectFactory>
  <parallel>${parallel}</parallel>
  <parallelMavenExecution default-value="${session.parallel}"/>
  <perCoreThreadCount default-value="true">${perCoreThreadCount}</perCoreThreadCount>
  <pluginArtifactMap>${plugin.artifactMap}</pluginArtifactMap>
  <pluginDescriptor default-value="${plugin}"/>
  <printSummary default-value="true">${surefire.printSummary}</printSummary>
  <projectArtifactMap>${project.artifactMap}</projectArtifactMap>
  <redirectTestOutputToFile default-value="false">${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
  <remoteRepositories default-value="${project.pluginArtifactRepositories}"/>
  <reportFormat default-value="brief">${surefire.reportFormat}</reportFormat>
  <reportNameSuffix default-value="">${surefire.reportNameSuffix}</reportNameSuffix>
  <reportsDirectory default-value="${project.build.directory}/surefire-reports"/>
  <runOrder default-value="filesystem"/>
  <skip default-value="false">${maven.test.skip}</skip>
  <skipExec>${maven.test.skip.exec}</skipExec>
  <skipTests default-value="false">${skipTests}</skipTests>
  <test>${test}</test>
  <testClassesDirectory default-value="${project.build.testOutputDirectory}"/>
  <testFailureIgnore default-value="false">${maven.test.failure.ignore}</testFailureIgnore>
  <testNGArtifactName default-value="org.testng:testng">${testNGArtifactName}</testNGArtifactName>
  <testSourceDirectory default-value="${project.build.testSourceDirectory}"/>
  <threadCount>${threadCount}</threadCount>
  <trimStackTrace default-value="true">${trimStackTrace}</trimStackTrace>
  <useFile default-value="true">${surefire.useFile}</useFile>
  <useManifestOnlyJar default-value="true">${surefire.useManifestOnlyJar}</useManifestOnlyJar>
  <useSystemClassLoader default-value="true">${surefire.useSystemClassLoader}</useSystemClassLoader>
  <useUnlimitedThreads default-value="false">${useUnlimitedThreads}</useUnlimitedThreads>
  <workingDirectory>${basedir}</workingDirectory>
  <project default-value="${project}"/>
  <session default-value="${session}"/>
</configuration>
[DEBUG] -----------------------------------------------------------------------
[DEBUG] Goal:          org.apache.maven.plugins:maven-jar-plugin:2.4:jar (default-jar)
[DEBUG] Style:         Regular
[DEBUG] Configuration: <?xml version="1.0" encoding="UTF-8"?>
<configuration>
  <classesDirectory default-value="${project.build.outputDirectory}"/>
  <defaultManifestFile default-value="${project.build.outputDirectory}/META-INF/MANIFEST.MF"/>
  <finalName default-value="${project.build.finalName}">${jar.finalName}</finalName>
  <forceCreation default-value="false">${jar.forceCreation}</forceCreation>
  <outputDirectory default-value="${project.build.directory}"/>
  <project default-value="${project}"/>
  <session default-value="${session}"/>
  <skipIfEmpty default-value="false">${jar.skipIfEmpty}</skipIfEmpty>
  <useDefaultManifestFile default-value="false">${jar.useDefaultManifestFile}</useDefaultManifestFile>
</configuration>
[DEBUG] =======================================================================
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=0, ConflictMarker.markTime=0, ConflictMarker.nodeCount=1, ConflictIdSorter.graphTime=0, ConflictIdSorter.topsortTime=0, ConflictIdSorter.conflictIdCount=0, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=0, ConflictResolver.conflictItemCount=0, DefaultDependencyCollector.collectTime=0, DefaultDependencyCollector.transformTime=0}
[DEBUG] EthicLab.Samples:ExampleCSharpMavenProject01:jar:1.0.0.0-SNAPSHOT
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ExampleCSharpMavenProject01 ---
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=0, ConflictMarker.markTime=0, ConflictMarker.nodeCount=3, ConflictIdSorter.graphTime=0, ConflictIdSorter.topsortTime=0, ConflictIdSorter.conflictIdCount=3, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=0, ConflictResolver.conflictItemCount=3, DefaultDependencyCollector.collectTime=16, DefaultDependencyCollector.transformTime=0}
[DEBUG] org.apache.maven.plugins:maven-clean-plugin:jar:2.5:
[DEBUG]    org.apache.maven:maven-plugin-api:jar:2.0.6:compile
[DEBUG]    org.codehaus.plexus:plexus-utils:jar:3.0:compile
[DEBUG] Created new class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.5
[DEBUG] Importing foreign packages into class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.5
[DEBUG]   Imported:  < project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Populating class realm plugin>org.apache.maven.plugins:maven-clean-plugin:2.5
[DEBUG]   Included: org.apache.maven.plugins:maven-clean-plugin:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:3.0
[DEBUG]   Excluded: org.apache.maven:maven-plugin-api:jar:2.0.6
[DEBUG] Configuring mojo org.apache.maven.plugins:maven-clean-plugin:2.5:clean from plugin realm ClassRealm[plugin>org.apache.maven.plugins:maven-clean-plugin:2.5, parent: sun.misc.Launcher$AppClassLoader@3b76d662]
[DEBUG] Configuring mojo 'org.apache.maven.plugins:maven-clean-plugin:2.5:clean' with basic configurator -->
[DEBUG]   (f) directory = /Users/montoyaedu/example-csharp-maven-project-01/target
[DEBUG]   (f) excludeDefaultDirectories = false
[DEBUG]   (f) failOnError = true
[DEBUG]   (f) followSymLinks = false
[DEBUG]   (f) outputDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG]   (f) reportDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/site
[DEBUG]   (f) retryOnError = true
[DEBUG]   (f) skip = false
[DEBUG]   (f) testOutputDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/test-classes
[DEBUG] -- end configuration --
[INFO] Deleting /Users/montoyaedu/example-csharp-maven-project-01/target
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target/maven-status/maven-compiler-plugin/compile/default-compile
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target/maven-status/maven-compiler-plugin/compile
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target/maven-status/maven-compiler-plugin
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target/maven-status
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[INFO] Deleting directory /Users/montoyaedu/example-csharp-maven-project-01/target
[DEBUG] Skipping non-existing directory /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG] Skipping non-existing directory /Users/montoyaedu/example-csharp-maven-project-01/target/test-classes
[DEBUG] Skipping non-existing directory /Users/montoyaedu/example-csharp-maven-project-01/target/site
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ ExampleCSharpMavenProject01 ---
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=0, ConflictMarker.markTime=1, ConflictMarker.nodeCount=77, ConflictIdSorter.graphTime=0, ConflictIdSorter.topsortTime=0, ConflictIdSorter.conflictIdCount=26, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=5, ConflictResolver.conflictItemCount=74, DefaultDependencyCollector.collectTime=73, DefaultDependencyCollector.transformTime=6}
[DEBUG] org.apache.maven.plugins:maven-resources-plugin:jar:2.6:
[DEBUG]    org.apache.maven:maven-plugin-api:jar:2.0.6:compile
[DEBUG]    org.apache.maven:maven-project:jar:2.0.6:compile
[DEBUG]       org.apache.maven:maven-profile:jar:2.0.6:compile
[DEBUG]       org.apache.maven:maven-artifact-manager:jar:2.0.6:compile
[DEBUG]       org.apache.maven:maven-plugin-registry:jar:2.0.6:compile
[DEBUG]    org.apache.maven:maven-core:jar:2.0.6:compile
[DEBUG]       org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6:compile
[DEBUG]       org.apache.maven.reporting:maven-reporting-api:jar:2.0.6:compile
[DEBUG]          org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7:compile
[DEBUG]       org.apache.maven:maven-repository-metadata:jar:2.0.6:compile
[DEBUG]       org.apache.maven:maven-error-diagnostics:jar:2.0.6:compile
[DEBUG]       commons-cli:commons-cli:jar:1.0:compile
[DEBUG]       org.apache.maven:maven-plugin-descriptor:jar:2.0.6:compile
[DEBUG]       org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4:compile
[DEBUG]       classworlds:classworlds:jar:1.1:compile
[DEBUG]    org.apache.maven:maven-artifact:jar:2.0.6:compile
[DEBUG]    org.apache.maven:maven-settings:jar:2.0.6:compile
[DEBUG]    org.apache.maven:maven-model:jar:2.0.6:compile
[DEBUG]    org.apache.maven:maven-monitor:jar:2.0.6:compile
[DEBUG]    org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
[DEBUG]       junit:junit:jar:3.8.1:compile
[DEBUG]    org.codehaus.plexus:plexus-utils:jar:2.0.5:compile
[DEBUG]    org.apache.maven.shared:maven-filtering:jar:1.1:compile
[DEBUG]       org.sonatype.plexus:plexus-build-api:jar:0.0.4:compile
[DEBUG]    org.codehaus.plexus:plexus-interpolation:jar:1.13:compile
[DEBUG] Created new class realm plugin>org.apache.maven.plugins:maven-resources-plugin:2.6
[DEBUG] Importing foreign packages into class realm plugin>org.apache.maven.plugins:maven-resources-plugin:2.6
[DEBUG]   Imported:  < project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Populating class realm plugin>org.apache.maven.plugins:maven-resources-plugin:2.6
[DEBUG]   Included: org.apache.maven.plugins:maven-resources-plugin:jar:2.6
[DEBUG]   Included: org.apache.maven.reporting:maven-reporting-api:jar:2.0.6
[DEBUG]   Included: org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7
[DEBUG]   Included: commons-cli:commons-cli:jar:1.0
[DEBUG]   Included: org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4
[DEBUG]   Included: junit:junit:jar:3.8.1
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:2.0.5
[DEBUG]   Included: org.apache.maven.shared:maven-filtering:jar:1.1
[DEBUG]   Included: org.sonatype.plexus:plexus-build-api:jar:0.0.4
[DEBUG]   Included: org.codehaus.plexus:plexus-interpolation:jar:1.13
[DEBUG]   Excluded: org.apache.maven:maven-plugin-api:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-project:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-profile:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-artifact-manager:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-plugin-registry:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-core:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-repository-metadata:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-error-diagnostics:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-plugin-descriptor:jar:2.0.6
[DEBUG]   Excluded: classworlds:classworlds:jar:1.1
[DEBUG]   Excluded: org.apache.maven:maven-artifact:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-settings:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-model:jar:2.0.6
[DEBUG]   Excluded: org.apache.maven:maven-monitor:jar:2.0.6
[DEBUG]   Excluded: org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1
[DEBUG] Configuring mojo org.apache.maven.plugins:maven-resources-plugin:2.6:resources from plugin realm ClassRealm[plugin>org.apache.maven.plugins:maven-resources-plugin:2.6, parent: sun.misc.Launcher$AppClassLoader@3b76d662]
[DEBUG] Configuring mojo 'org.apache.maven.plugins:maven-resources-plugin:2.6:resources' with basic configurator -->
[DEBUG]   (f) buildFilters = []
[DEBUG]   (f) encoding = UTF-8
[DEBUG]   (f) escapeWindowsPaths = true
[DEBUG]   (s) includeEmptyDirs = false
[DEBUG]   (s) outputDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG]   (s) overwrite = false
[DEBUG]   (f) project = MavenProject: EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT @ /Users/montoyaedu/example-csharp-maven-project-01/pom.xml
[DEBUG]   (s) resources = [Resource {targetPath: null, filtering: false, FileSet {directory: /Users/montoyaedu/example-csharp-maven-project-01/src/main/resources, PatternSet [includes: {}, excludes: {}]}}]
[DEBUG]   (f) session = org.apache.maven.execution.MavenSession@793a2cd7
[DEBUG]   (f) supportMultiLineFiltering = false
[DEBUG]   (f) useBuildFilters = true
[DEBUG]   (s) useDefaultDelimiters = true
[DEBUG] -- end configuration --
[DEBUG] properties used {java.vendor=Oracle Corporation, env.ASCIIDOCTORJ_HOME=/Users/montoyaedu/.gvm/asciidoctorj/current, sun.java.launcher=SUN_STANDARD, env.XPC_SERVICE_NAME=0, sun.management.compiler=HotSpot 64-Bit Tiered Compilers, env.PROMPT_COMMAND=history -a; history -c; history -r; update_terminal_cwd; , os.name=Mac OS X, env.PYTHONPATH=/usr/local/lib/python2.7/site-packages:, sun.boot.class.path=/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/sunrsasign.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/JObjC.jar:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/classes, env.TMPDIR=/var/folders/m8/s4ym2gcn00b545jyy4261j6c0000gp/T/, env.SPRINGBOOT_HOME=/Users/montoyaedu/.gvm/springboot/current, env.PWD=/Users/montoyaedu/example-csharp-maven-project-01, user.country.format=IT, java.vm.specification.vendor=Oracle Corporation, java.runtime.version=1.7.0_40-ea-b31, env.HISTSIZE=1000000, env.Apple_PubSub_Socket_Render=/private/tmp/com.apple.launchd.cTSbDF69ac/Render, project.build.sourceEncoding=UTF-8, env.DISPLAY=/private/tmp/com.apple.launchd.iN6sM8shI5/org.macosforge.xquartz:0, env.GVM_SERVICE=http://api.gvmtool.net, user.name=montoyaedu, maven.build.version=Apache Maven 3.2.1 (ea8b2b07643dbb1b84b6d16e1f08391b666bc1e9; 2014-02-14T18:37:52+01:00), env.USER=montoyaedu, env.HISTCONTROL=erasedups, env.SHELL=/bin/bash, env.__CF_USER_TEXT_ENCODING=0x1F6:0x0:0x0, env.GVM_DIR=/Users/montoyaedu/.gvm, env.HISTFILESIZE=1000000000, env.PATH=/Users/montoyaedu/.gvm/vertx/current/bin:/Users/montoyaedu/.gvm/springboot/current/bin:/Users/montoyaedu/.gvm/lazybones/current/bin:/Users/montoyaedu/.gvm/jbake/current/bin:/Users/montoyaedu/.gvm/groovyserv/current/bin:/Users/montoyaedu/.gvm/groovy/current/bin:/Users/montoyaedu/.gvm/griffon/current/bin:/Users/montoyaedu/.gvm/grails/current/bin:/Users/montoyaedu/.gvm/gradle/current/bin:/Users/montoyaedu/.gvm/glide/current/bin:/Users/montoyaedu/.gvm/gaiden/current/bin:/Users/montoyaedu/.gvm/crash/current/bin:/Users/montoyaedu/.gvm/asciidoctorj/current/bin:/opt/adt-bundle-mac-x86_64-20140321/sdk/tools:/usr/local/opt/ruby/bin:/opt/adt-bundle-mac-x86_64-20140321/sdk/platform-tools:/usr/texbin:/opt/robovm-0.0.12-SNAPSHOT/bin:/Users/emontoya/Library/Python/2.7/bin:/opt/local/bin:/opt/local/sbin:/adt-bundle-mac-x86_64/sdk/tools:/adt-bundle-mac-x86_64/sdk/platform-tools:/usr/local/opt/ruby/bin:/usr/libexec:/scripts:/usr/local/bin:/usr/local/sbin:/sbin:/bin:/usr/bin:/usr/sbin:/usr/local/mysql/bin:/opt/instantclient_10_2, user.language=en, sun.boot.library.path=/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib, classworlds.conf=/usr/local/Cellar/maven/3.2.1/libexec/bin/m2.conf, env.XPC_FLAGS=0x0, env.LC_CTYPE=UTF-8, java.version=1.7.0_40-ea, env.GVM_BROKER_SERVICE=http://release.gvm.io, user.timezone=Europe/Rome, env.CRASH_HOME=/Users/montoyaedu/.gvm/crash/current, sun.arch.data.model=64, http.nonProxyHosts=local|*.local|169.254/16|*.169.254/16, java.endorsed.dirs=/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/endorsed, sun.cpu.isalist=, sun.jnu.encoding=UTF-8, file.encoding.pkg=sun.io, env.SHLVL=1, file.separator=/, java.specification.name=Java Platform API Specification, env.GROOVY_HOME=/Users/montoyaedu/.gvm/groovy/current, java.class.version=51.0, org.slf4j.simpleLogger.defaultLogLevel=debug, user.country=US, env.GRADLE_HOME=/Users/montoyaedu/.gvm/gradle/current, java.home=/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre, env.ANDROID_HOME=/opt/adt-bundle-mac-x86_64-20140321/sdk, java.vm.info=mixed mode, env.JBAKE_HOME=/Users/montoyaedu/.gvm/jbake/current, env.LOGNAME=montoyaedu, os.version=10.10.3, env.TERM_PROGRAM_VERSION=343.7, env.CLICOLOR=1, path.separator=:, env.GVM_VERSION=2.4.1, env.VERTX_HOME=/Users/montoyaedu/.gvm/vertx/current, java.vm.version=24.0-b50, env.GVM_PLATFORM=Darwin, env.GROOVYSERV_HOME=/Users/montoyaedu/.gvm/groovyserv/current, env.JAVA_MAIN_CLASS_1704=org.codehaus.plexus.classworlds.launcher.Launcher, env.JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home, java.awt.printerjob=sun.lwawt.macosx.CPrinterJob, env.TERM=xterm-256color, sun.io.unicode.encoding=UnicodeBig, awt.toolkit=sun.lwawt.macosx.LWCToolkit, socksNonProxyHosts=local|*.local|169.254/16|*.169.254/16, env.GLIDE_HOME=/Users/montoyaedu/.gvm/glide/current, ftp.nonProxyHosts=local|*.local|169.254/16|*.169.254/16, env.LSCOLORS=exfxcxdxbxegedabagacad, user.home=/Users/montoyaedu, env.OLDPWD=/Users/montoyaedu/example-csharp-maven-project-01, java.specification.vendor=Oracle Corporation, env.CLASSPATH=.:/usr/local/lib/antlr-4.2.2-complete.jar:, env.TERM_PROGRAM=Apple_Terminal, env.HISTTIMEFORMAT=%Y%m%d-%T , java.library.path=/Users/montoyaedu/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:., java.vendor.url=http://java.oracle.com/, env.MAVEN_CMD_LINE_ARGS=-X clean package, java.vm.vendor=Oracle Corporation, gopherProxySet=false, maven.home=/usr/local/Cellar/maven/3.2.1/libexec, java.runtime.name=Java(TM) SE Runtime Environment, sun.java.command=org.codehaus.plexus.classworlds.launcher.Launcher -X clean package, java.class.path=/usr/local/Cellar/maven/3.2.1/libexec/boot/plexus-classworlds-2.5.1.jar, env.TERM_SESSION_ID=3D617CCD-E5DA-4524-B0D9-CEF8A370B7D9, env.GVM_INIT=true, maven.version=3.2.1, java.vm.specification.name=Java Virtual Machine Specification, env.GRIFFON_HOME=/Users/montoyaedu/.gvm/griffon/current, java.vm.specification.version=1.7, sun.cpu.endian=little, sun.os.patch.level=unknown, env.HOME=/Users/montoyaedu, java.io.tmpdir=/var/folders/m8/s4ym2gcn00b545jyy4261j6c0000gp/T/, java.vendor.url.bug=http://bugreport.sun.com/bugreport/, env.SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.h6ZormuHQA/Listeners, os.arch=x86_64, java.awt.graphicsenv=sun.awt.CGraphicsEnvironment, env.LAZYBONES_HOME=/Users/montoyaedu/.gvm/lazybones/current, env.GAIDEN_HOME=/Users/montoyaedu/.gvm/gaiden/current, java.ext.dirs=/Users/montoyaedu/Library/Java/Extensions:/Library/Java/JavaVirtualMachines/jdk1.7.0_40.jdk/Contents/Home/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java, user.dir=/Users/montoyaedu/example-csharp-maven-project-01, line.separator=
, java.vm.name=Java HotSpot(TM) 64-Bit Server VM, env.EDITOR=vi, file.encoding=UTF-8, env.GRAILS_HOME=/Users/montoyaedu/.gvm/grails/current, env.GVM_BROADCAST_SERVICE=http://cast.gvm.io, java.specification.version=1.7}
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[DEBUG] resource with targetPath null
directory /Users/montoyaedu/example-csharp-maven-project-01/src/main/resources
excludes []
includes []
[INFO] skip non existing resourceDirectory /Users/montoyaedu/example-csharp-maven-project-01/src/main/resources
[DEBUG] no use filter components
[INFO] 
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ ExampleCSharpMavenProject01 ---
[DEBUG] Dependency collection stats: {ConflictMarker.analyzeTime=1, ConflictMarker.markTime=0, ConflictMarker.nodeCount=147, ConflictIdSorter.graphTime=1, ConflictIdSorter.topsortTime=0, ConflictIdSorter.conflictIdCount=45, ConflictIdSorter.conflictIdCycleCount=0, ConflictResolver.totalTime=6, ConflictResolver.conflictItemCount=76, DefaultDependencyCollector.collectTime=19, DefaultDependencyCollector.transformTime=8}
[DEBUG] org.apache.maven.plugins:maven-compiler-plugin:jar:3.3:
[DEBUG]    org.codehaus.plexus:plexus-compiler-csharp:jar:2.5:runtime
[DEBUG]       org.codehaus.plexus:plexus-utils:jar:3.0.10:compile
[DEBUG]    org.apache.maven:maven-plugin-api:jar:2.2.1:compile
[DEBUG]    org.apache.maven:maven-artifact:jar:2.2.1:compile
[DEBUG]    org.apache.maven:maven-core:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-settings:jar:2.2.1:compile
[DEBUG]          org.codehaus.plexus:plexus-interpolation:jar:1.11:compile
[DEBUG]       org.apache.maven:maven-plugin-parameter-documenter:jar:2.2.1:compile
[DEBUG]       org.slf4j:slf4j-jdk14:jar:1.5.6:runtime
[DEBUG]          org.slf4j:slf4j-api:jar:1.5.6:runtime
[DEBUG]       org.slf4j:jcl-over-slf4j:jar:1.5.6:runtime
[DEBUG]       org.apache.maven:maven-profile:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-model:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-repository-metadata:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-error-diagnostics:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-project:jar:2.2.1:compile
[DEBUG]          org.apache.maven:maven-plugin-registry:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-plugin-descriptor:jar:2.2.1:compile
[DEBUG]       org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
[DEBUG]          backport-util-concurrent:backport-util-concurrent:jar:3.1:compile
[DEBUG]       org.apache.maven:maven-monitor:jar:2.2.1:compile
[DEBUG]       org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
[DEBUG]          org.sonatype.plexus:plexus-cipher:jar:1.4:compile
[DEBUG]    org.apache.maven:maven-toolchain:jar:2.2.1:compile
[DEBUG]    org.apache.maven.shared:maven-shared-utils:jar:0.7:compile
[DEBUG]       com.google.code.findbugs:jsr305:jar:2.0.1:compile
[DEBUG]    org.apache.maven.shared:maven-shared-incremental:jar:1.1:compile
[DEBUG]       org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-api:jar:2.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-manager:jar:2.5:compile
[DEBUG]    org.codehaus.plexus:plexus-compiler-javac:jar:2.5:runtime
[DEBUG]    org.codehaus.plexus:plexus-container-default:jar:1.5.5:compile
[DEBUG]       org.codehaus.plexus:plexus-classworlds:jar:2.2.2:compile
[DEBUG]       org.apache.xbean:xbean-reflect:jar:3.4:compile
[DEBUG]          log4j:log4j:jar:1.2.12:compile
[DEBUG]          commons-logging:commons-logging-api:jar:1.1:compile
[DEBUG]       com.google.collections:google-collections:jar:1.0:compile
[DEBUG]       junit:junit:jar:3.8.2:compile
[DEBUG] Created new class realm plugin>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG] Importing foreign packages into class realm plugin>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG]   Imported:  < project>EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT
[DEBUG] Populating class realm plugin>org.apache.maven.plugins:maven-compiler-plugin:3.3
[DEBUG]   Included: org.apache.maven.plugins:maven-compiler-plugin:jar:3.3
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-csharp:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-utils:jar:3.0.10
[DEBUG]   Included: org.codehaus.plexus:plexus-interpolation:jar:1.11
[DEBUG]   Included: org.slf4j:slf4j-jdk14:jar:1.5.6
[DEBUG]   Included: org.slf4j:slf4j-api:jar:1.5.6
[DEBUG]   Included: org.slf4j:jcl-over-slf4j:jar:1.5.6
[DEBUG]   Included: backport-util-concurrent:backport-util-concurrent:jar:3.1
[DEBUG]   Included: org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3
[DEBUG]   Included: org.sonatype.plexus:plexus-cipher:jar:1.4
[DEBUG]   Included: org.apache.maven.shared:maven-shared-utils:jar:0.7
[DEBUG]   Included: com.google.code.findbugs:jsr305:jar:2.0.1
[DEBUG]   Included: org.apache.maven.shared:maven-shared-incremental:jar:1.1
[DEBUG]   Included: org.codehaus.plexus:plexus-component-annotations:jar:1.5.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-api:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-manager:jar:2.5
[DEBUG]   Included: org.codehaus.plexus:plexus-compiler-javac:jar:2.5
[DEBUG]   Included: org.apache.xbean:xbean-reflect:jar:3.4
[DEBUG]   Included: log4j:log4j:jar:1.2.12
[DEBUG]   Included: commons-logging:commons-logging-api:jar:1.1
[DEBUG]   Included: com.google.collections:google-collections:jar:1.0
[DEBUG]   Included: junit:junit:jar:3.8.2
[DEBUG]   Excluded: org.apache.maven:maven-plugin-api:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-artifact:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-core:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-settings:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-plugin-parameter-documenter:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-profile:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-model:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-repository-metadata:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-error-diagnostics:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-project:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-plugin-registry:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-plugin-descriptor:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-artifact-manager:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-monitor:jar:2.2.1
[DEBUG]   Excluded: org.apache.maven:maven-toolchain:jar:2.2.1
[DEBUG]   Excluded: org.codehaus.plexus:plexus-container-default:jar:1.5.5
[DEBUG]   Excluded: org.codehaus.plexus:plexus-classworlds:jar:2.2.2
[DEBUG] Configuring mojo org.apache.maven.plugins:maven-compiler-plugin:3.3:compile from plugin realm ClassRealm[plugin>org.apache.maven.plugins:maven-compiler-plugin:3.3, parent: sun.misc.Launcher$AppClassLoader@3b76d662]
[DEBUG] Configuring mojo 'org.apache.maven.plugins:maven-compiler-plugin:3.3:compile' with basic configurator -->
[DEBUG]   (f) basedir = /Users/montoyaedu/example-csharp-maven-project-01
[DEBUG]   (f) buildDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target
[DEBUG]   (f) classpathElements = [/Users/montoyaedu/example-csharp-maven-project-01/target/classes]
[DEBUG]   (f) compileSourceRoots = [/Users/montoyaedu/example-csharp-maven-project-01]
[DEBUG]   (f) compilerId = csharp
[DEBUG]   (f) debug = true
[DEBUG]   (f) encoding = UTF-8
[DEBUG]   (f) excludes = [target, obj, bin]
[DEBUG]   (f) failOnError = true
[DEBUG]   (f) forceJavacCompilerUse = false
[DEBUG]   (f) fork = true
[DEBUG]   (f) generatedSourcesDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations
[DEBUG]   (f) mojoExecution = org.apache.maven.plugins:maven-compiler-plugin:3.3:compile {execution: default-compile}
[DEBUG]   (f) optimize = false
[DEBUG]   (f) outputDirectory = /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG]   (f) outputFileName = ExampleCSharpMavenProject01
[DEBUG]   (f) project = MavenProject: EthicLab.Samples:ExampleCSharpMavenProject01:1.0.0.0-SNAPSHOT @ /Users/montoyaedu/example-csharp-maven-project-01/pom.xml
[DEBUG]   (f) projectArtifact = EthicLab.Samples:ExampleCSharpMavenProject01:jar:1.0.0.0-SNAPSHOT
[DEBUG]   (f) session = org.apache.maven.execution.MavenSession@793a2cd7
[DEBUG]   (f) showDeprecation = false
[DEBUG]   (f) showWarnings = false
[DEBUG]   (f) skipMultiThreadWarning = false
[DEBUG]   (f) source = 1.5
[DEBUG]   (f) staleMillis = 0
[DEBUG]   (f) target = 1.5
[DEBUG]   (f) useIncrementalCompilation = true
[DEBUG]   (f) verbose = false
[DEBUG] -- end configuration --
[DEBUG] Using compiler 'csharp'.
[DEBUG] Source directories: [/Users/montoyaedu/example-csharp-maven-project-01]
[DEBUG] Classpath: [/Users/montoyaedu/example-csharp-maven-project-01/target/classes]
[DEBUG] Output directory: /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG] Adding /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations to compile source roots:
  /Users/montoyaedu/example-csharp-maven-project-01
[DEBUG] New compile source roots:
  /Users/montoyaedu/example-csharp-maven-project-01
  /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations
[DEBUG] CompilerReuseStrategy: reuseCreated
[DEBUG] useIncrementalCompilation enabled
[INFO] Changes detected - recompiling the module!
[DEBUG] Classpath:
[DEBUG]  /Users/montoyaedu/example-csharp-maven-project-01/target/classes
[DEBUG] Source roots:
[DEBUG]  /Users/montoyaedu/example-csharp-maven-project-01
[DEBUG]  /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations
Looking for resourcesDir
No resourceDir was available.
[DEBUG] Command line options:
[DEBUG] /debug+ /out:/Users/montoyaedu/example-csharp-maven-project-01/target/classes/ExampleCSharpMavenProject01.dll /target:library /Users/montoyaedu/example-csharp-maven-project-01/Main.cs
[DEBUG] incrementalBuildHelper#beforeRebuildExecution
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.115 s
[INFO] Finished at: 2015-05-22T15:10:42+01:00
[INFO] Final Memory: 8M/245M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project ExampleCSharpMavenProject01: Fatal error compiling: basedir /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations does not exist -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project ExampleCSharpMavenProject01: Fatal error compiling
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:108)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:76)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:116)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:361)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Fatal error compiling
	at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:836)
	at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:129)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:133)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 19 more
Caused by: java.lang.IllegalStateException: basedir /Users/montoyaedu/example-csharp-maven-project-01/target/generated-sources/annotations does not exist
	at org.codehaus.plexus.util.DirectoryScanner.scan(DirectoryScanner.java:305)
	at org.codehaus.plexus.compiler.csharp.CSharpCompiler.getSourceFilesForSourceRoot(CSharpCompiler.java:606)
	at org.codehaus.plexus.compiler.csharp.CSharpCompiler.getSourceFiles(CSharpCompiler.java:550)
	at org.codehaus.plexus.compiler.csharp.CSharpCompiler.performCompile(CSharpCompiler.java:102)
	at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:825)
	... 22 more
[ERROR] 
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
`````

