### PR TITLE
Lookup correct "properties" key for Eclipse

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -183,10 +183,10 @@ public class EclipseJavaCompiler
 
         settings.putAll( extras );
 
-        if ( settings.containsKey( "-properties" ) )
+        if ( settings.containsKey( "properties" ) )
         {
-            initializeWarnings( settings.get( "-properties" ), settings );
-            settings.remove( "-properties" );
+            initializeWarnings( settings.get( "properties" ), settings );
+            settings.remove( "properties" );
         }
 
         IProblemFactory problemFactory = new DefaultProblemFactory( Locale.getDefault() );

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -101,6 +101,26 @@ public class EclipseCompilerTest
 
     }
 
+    public void testInitializeWarningsForPropertiesArgument()
+        throws Exception
+    {
+        org.codehaus.plexus.compiler.Compiler compiler = (Compiler) lookup( Compiler.ROLE, getRoleHint() );
+
+        CompilerConfiguration compilerConfig = createMinimalCompilerConfig();
+
+        compilerConfig.addCompilerCustomArgument( "-properties", "file_does_not_exist" );
+
+        try
+        {
+            compiler.performCompile( compilerConfig );
+            fail( "looking up the properties file should have thrown an exception" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( "Properties file not exist", e.getMessage() );
+        }
+    }
+
     private CompilerConfiguration createMinimalCompilerConfig()
     {
         CompilerConfiguration compilerConfig = new CompilerConfiguration();


### PR DESCRIPTION
Since we now clean leading dashes from configuration keys (870d1ee),
lookup "properties" instead of "-properties".