### PR TITLE
Add new compiler config "warningsAreErrors".

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -90,6 +90,8 @@ public class CompilerConfiguration
 
     private boolean verbose = false;
 
+    private boolean warningsAreErrors = false;
+
     /**
      * A build temporary directory, eg target/.
      * <p/>
@@ -360,8 +362,8 @@ public class CompilerConfiguration
         {
             this.customCompilerArguments = customCompilerArguments;
         }
-    }    
-    
+    }
+
     public Map<String, String> getCustomCompilerArgumentsAsMap()
     {
         return new LinkedHashMap<String, String>( customCompilerArguments );
@@ -467,6 +469,16 @@ public class CompilerConfiguration
     public void setCompilerVersion( String compilerVersion )
     {
         this.compilerVersion = compilerVersion;
+    }
+
+    public boolean isWarningsAreErrors()
+    {
+        return warningsAreErrors;
+    }
+
+    public void setWarningsAreErrors( boolean warningsAreErrors )
+    {
+        this.warningsAreErrors = warningsAreErrors;
     }
 
     public boolean isVerbose()

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -88,10 +88,24 @@ public abstract class AbstractCompilerTest
     public void testCompilingSources()
         throws Exception
     {
+        performSourceCompilation( false );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public void testCompilingSourcesWithWarningsAreErrors()
+        throws Exception
+    {
+        performSourceCompilation( true );
+    }
+
+
+    private void performSourceCompilation(  boolean warningsAreErrors )
+        throws Exception
+    {
         List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
         Collection<String> files = new TreeSet<String>();
 
-        for ( CompilerConfiguration compilerConfig : getCompilerConfigurations() )
+        for ( CompilerConfiguration compilerConfig : getCompilerConfigurations( warningsAreErrors ) )
         {
             File outputDir = new File( compilerConfig.getOutputLocation() );
 
@@ -109,7 +123,7 @@ public abstract class AbstractCompilerTest
 
         int numCompilerWarnings = messages.size() - numCompilerErrors;
 
-        if ( expectedErrors() != numCompilerErrors )
+        if ( expectedErrors( warningsAreErrors ) != numCompilerErrors )
         {
             System.out.println( numCompilerErrors + " error(s) found:" );
             for ( CompilerMessage error : messages )
@@ -125,10 +139,10 @@ public abstract class AbstractCompilerTest
                 System.out.println( "----" );
             }
 
-            assertEquals( "Wrong number of compilation errors.", expectedErrors(), numCompilerErrors );
+            assertEquals( "Wrong number of compilation errors.", expectedErrors( warningsAreErrors ), numCompilerErrors );
         }
 
-        if ( expectedWarnings() != numCompilerWarnings )
+        if ( expectedWarnings( warningsAreErrors ) != numCompilerWarnings )
         {
             System.out.println( numCompilerWarnings + " warning(s) found:" );
             for ( CompilerMessage error : messages )
@@ -144,13 +158,13 @@ public abstract class AbstractCompilerTest
                 System.out.println( "----" );
             }
 
-            assertEquals( "Wrong number of compilation warnings.", expectedWarnings(), numCompilerWarnings );
+            assertEquals( "Wrong number of compilation warnings.", expectedWarnings( warningsAreErrors ), numCompilerWarnings );
         }
 
-        assertEquals( new TreeSet<String>( normalizePaths( expectedOutputFiles() ) ), files );
+        assertEquals( new TreeSet<String>( normalizePaths( expectedOutputFiles( warningsAreErrors ) ) ), files );
     }
 
-    private List<CompilerConfiguration> getCompilerConfigurations()
+    private List<CompilerConfiguration> getCompilerConfigurations( boolean warningsAreErrors )
         throws Exception
     {
         String sourceDir = getBasedir() + "/src/test-input/src/main";
@@ -183,6 +197,8 @@ public abstract class AbstractCompilerTest
             compilerConfig.addInclude( filename );
 
             compilerConfig.setForceJavacCompilerUse( this.forceJavacCompilerUse );
+
+            compilerConfig.setWarningsAreErrors( warningsAreErrors );
 
             //compilerConfig.setTargetVersion( "1.5" );
 
@@ -217,17 +233,17 @@ public abstract class AbstractCompilerTest
         return count;
     }
 
-    protected int expectedErrors()
+    protected int expectedErrors( boolean warningsAreErrors )
     {
         return 1;
     }
 
-    protected int expectedWarnings()
+    protected int expectedWarnings( boolean warningsAreErrors )
     {
         return 0;
     }
 
-    protected Collection<String> expectedOutputFiles()
+    protected Collection<String> expectedOutputFiles( boolean warningsAreErrors )
     {
         return Collections.emptyList();
     }

--- a/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
@@ -28,7 +28,8 @@ public class AspectJCompilerTest
         return 1;
     }
 
-    protected Collection<String> expectedOutputFiles()
+    @Override
+    protected Collection<String> expectedOutputFiles( boolean warningsAreErrors )
     {
         return Arrays.asList( new String[]{ "org/codehaus/foo/ExternalDeps.class", "org/codehaus/foo/Person.class" } );
     }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -53,17 +53,20 @@ public class EclipseCompilerTest
         return "eclipse";
     }
 
-    protected int expectedErrors()
+    @Override
+    protected int expectedErrors( boolean warningsAreErrors )
     {
         return 4;
     }
 
-    protected int expectedWarnings()
+    @Override
+    protected int expectedWarnings( boolean warningsAreErrors )
     {
         return 2;
     }
 
-    protected Collection<String> expectedOutputFiles()
+    @Override
+    protected Collection<String> expectedOutputFiles( boolean warningsAreErrors )
     {
         return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
             "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class" } );

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
@@ -189,6 +189,11 @@ public class J2ObjCCompiler extends AbstractCompiler {
 			args.add("-v");
 		}
 
+		// warningsAreErrors
+		if (config.isWarningsAreErrors()) {
+			args.add("-Werror");
+		}
+
 		// Destination/output directory
 		args.add("-d");
 		args.add(config.getOutputLocation());

--- a/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
@@ -25,7 +25,6 @@ package org.codehaus.plexus.compiler.javac;
  */
 
 import org.codehaus.plexus.compiler.AbstractCompilerTest;
-import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
@@ -54,18 +53,21 @@ public class JavacErrorProneCompilerTest
     {
         return "javac-with-errorprone";
     }
-    protected int expectedWarnings()
+
+    @Override
+    protected int expectedWarnings( boolean warningsAreErrors )
     {
         return 10;
     }
 
     @Override
-    protected int expectedErrors()
+    protected int expectedErrors( boolean warningsAreErrors )
     {
         return 4;
     }
 
-    protected Collection<String> expectedOutputFiles()
+    @Override
+    protected Collection<String> expectedOutputFiles( boolean warningsAreErrors )
     {
         return Arrays.asList( new String[]{ "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
             "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class" } );

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -45,6 +45,7 @@ import org.codehaus.plexus.compiler.AbstractCompiler;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.codehaus.plexus.compiler.CompilerException;
 import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerMessage.Kind;
 import org.codehaus.plexus.compiler.CompilerOutputStyle;
 import org.codehaus.plexus.compiler.CompilerResult;
 import org.codehaus.plexus.util.FileUtils;
@@ -292,6 +293,11 @@ public class JavacCompiler
             args.add( "-verbose" );
         }
 
+        if ( config.isWarningsAreErrors() )
+        {
+            args.add( "-Werror" );
+        }
+
         if ( config.isShowDeprecation() )
         {
             args.add( "-deprecation" );
@@ -360,6 +366,10 @@ public class JavacCompiler
         return args.toArray( new String[args.size()] );
     }
 
+    private static final String [] PRE_JDK14 = new String [] { "1.3", "1.2", "1.1", "1.0" };
+    private static final String [] PRE_JDK16 = new String [] { "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+    private static final String [] PRE_JDK17 = new String [] { "1.6", "1.5", "1.4", "1.3", "1.2", "1.1", "1.0" };
+
     /**
      * Determine if the compiler is a version prior to 1.4.
      * This is needed as 1.3 and earlier did not support -source or -encoding parameters
@@ -367,16 +377,60 @@ public class JavacCompiler
      * @param config The compiler configuration to test.
      * @return true if the compiler configuration represents a Java 1.4 compiler or later, false otherwise
      */
-    private static boolean isPreJava14( CompilerConfiguration config )
+    static boolean isPreJava14( CompilerConfiguration config )
+    {
+        return checkJdk ( config, null, PRE_JDK14 );
+    }
+
+    private static boolean checkJdk( CompilerConfiguration config, String [] sourceVersionCheck, String [] compilerVersionCheck )
     {
         String v = config.getCompilerVersion();
 
         if ( v == null )
         {
-            return false;
+            if ( sourceVersionCheck == null )
+            {
+                return false;
+            }
+
+            //mkleint: i haven't completely understood the reason for the
+            //compiler version parameter, checking source as well, as most projects will have this one set, not the compiler
+            String s = config.getSourceVersion();
+            if ( s == null )
+            {
+                //now return true, as the 1.6 version is not the default - 1.4 is.
+                return true;
+            }
+
+            return versionCheck(s, sourceVersionCheck);
         }
 
-        return v.startsWith( "1.3" ) || v.startsWith( "1.2" ) || v.startsWith( "1.1" ) || v.startsWith( "1.0" );
+        return versionCheck(v, compilerVersionCheck);
+    }
+
+    private static boolean versionCheck( String v, String [] versionStrings )
+    {
+        for ( String s : versionStrings )
+        {
+            if ( ! v.startsWith( s ) )
+            {
+                continue;
+            }
+
+            if ( v.length() == s.length() )
+            {
+                return true;
+            }
+
+            // Return true if both strings are the same length or the first character in the
+            // checked string is not a number. This ensures that 1.10 does not match for 1.1.
+            // Otherwise, Java 10 will be a problem.
+            if ( ! Character.isDigit( v.charAt( s.length() ) ) )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -386,28 +440,22 @@ public class JavacCompiler
      * @param config The compiler configuration to test.
      * @return true if the compiler configuration represents a Java 1.6 compiler or later, false otherwise
      */
-    private static boolean isPreJava16( CompilerConfiguration config )
+    static boolean isPreJava16( CompilerConfiguration config )
     {
-        String v = config.getCompilerVersion();
-
-        if ( v == null )
-        {
-            //mkleint: i haven't completely understood the reason for the
-            //compiler version parameter, checking source as well, as most projects will have this one set, not the compiler
-            String s = config.getSourceVersion();
-            if ( s == null )
-            {
-                //now return true, as the 1.6 version is not the default - 1.4 is.
-                return true;
-            }
-            return s.startsWith( "1.5" ) || s.startsWith( "1.4" ) || s.startsWith( "1.3" ) || s.startsWith( "1.2" )
-                || s.startsWith( "1.1" ) || s.startsWith( "1.0" );
-        }
-
-        return v.startsWith( "1.5" ) || v.startsWith( "1.4" ) || v.startsWith( "1.3" ) || v.startsWith( "1.2" )
-            || v.startsWith( "1.1" ) || v.startsWith( "1.0" );
+        return checkJdk ( config, PRE_JDK16, PRE_JDK16 );
     }
 
+    /**
+     * Determine if the compiler is a version prior to 1.7.
+     * This is needed for the warningAreErrors setting.
+     *
+     * @param config The compiler configuration to test.
+     * @return true if the compiler configuration represents a Java 1.7 compiler or later, false otherwise
+     */
+    static boolean isPreJava17( CompilerConfiguration config )
+    {
+        return checkJdk ( config, PRE_JDK17, PRE_JDK17);
+    }
 
     private static boolean suppressSource( CompilerConfiguration config )
     {
@@ -630,7 +678,11 @@ public class JavacCompiler
                 // TODO: there should be a better way to parse these
                 if ( ( buffer.length() == 0 ) && line.startsWith( "error: " ) )
                 {
-                    errors.add( new CompilerMessage( line, true ) );
+                    errors.add( new CompilerMessage( line, Kind.ERROR ) );
+                }
+                else if ( ( buffer.length() == 0 ) && line.startsWith( "warning: " ) )
+                {
+                    errors.add( new CompilerMessage( line, Kind.WARNING ) );
                 }
                 else if ( ( buffer.length() == 0 ) && isNote( line ) )
                 {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
@@ -25,21 +25,4 @@ public class JavaxToolsCompilerTest
     extends AbstractJavacCompilerTest
 {
     // no op default is to javax.tools if available
-
-    protected int expectedWarnings()
-    {
-        if (getJavaVersion().contains("1.8")){
-            // lots of new warnings about obsoletions for future releases
-            return 30;
-        }
-        else if ( "1.6".compareTo( getJavaVersion() ) < 0 )
-        {
-            // with 1.7 some warning with bootstrap class path not set in conjunction with -source 1.3
-            return 9;
-        }
-        else
-        {
-            return 2;
-        }
-    }
 }

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JdkVersionTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JdkVersionTest.java
@@ -1,0 +1,139 @@
+package org.codehaus.plexus.compiler.javac;
+
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public class JdkVersionTest
+    extends TestCase
+{
+    public void testJdk14()
+    {
+        int cutoff = 4;
+
+        for ( int i = 10; i >= 0; i-- )
+        {
+            String test = "1." + i;
+            CompilerConfiguration config = new CompilerConfiguration();
+            config.setCompilerVersion( test );
+            boolean result = JavacCompiler.isPreJava14(config);
+            if (i < cutoff)
+            {
+                Assert.assertTrue( result );
+            }
+            else
+            {
+                Assert.assertFalse( result );
+            }
+        }
+    }
+
+    public void testJdk16()
+    {
+        int cutoff = 6;
+
+        for ( int i = 10; i >= 0; i-- )
+        {
+            String test = "1." + i;
+            CompilerConfiguration config = new CompilerConfiguration();
+            config.setCompilerVersion( test );
+            boolean result = JavacCompiler.isPreJava16(config);
+            if (i < cutoff)
+            {
+                Assert.assertTrue( result );
+            }
+            else
+            {
+                Assert.assertFalse( result );
+            }
+        }
+    }
+
+    public void testJdk16Source()
+    {
+        int cutoff = 6;
+
+        for ( int i = 10; i >= 0; i-- )
+        {
+            String test = "1." + i;
+            CompilerConfiguration config = new CompilerConfiguration();
+            config.setSourceVersion( test );
+            boolean result = JavacCompiler.isPreJava16(config);
+            if (i < cutoff)
+            {
+                Assert.assertTrue( result );
+            }
+            else
+            {
+                Assert.assertFalse( result );
+            }
+        }
+    }
+
+    public void testJdk17()
+    {
+        int cutoff = 6;
+
+        for ( int i = 10; i >= 0; i-- )
+        {
+            String test = "1." + i;
+            CompilerConfiguration config = new CompilerConfiguration();
+            config.setCompilerVersion( test );
+            boolean result = JavacCompiler.isPreJava16(config);
+            if (i < cutoff)
+            {
+                Assert.assertTrue( result );
+            }
+            else
+            {
+                Assert.assertFalse( result );
+            }
+        }
+    }
+
+    public void testJdk17Source()
+    {
+        int cutoff = 6;
+
+        for ( int i = 10; i >= 0; i-- )
+        {
+            String test = "1." + i;
+            CompilerConfiguration config = new CompilerConfiguration();
+            config.setSourceVersion( test );
+            boolean result = JavacCompiler.isPreJava16(config);
+            if (i < cutoff)
+            {
+                Assert.assertTrue( result );
+            }
+            else
+            {
+                Assert.assertFalse( result );
+            }
+        }
+    }
+}

--- a/plexus-compilers/plexus-compiler-jikes/src/main/java/org/codehaus/plexus/compiler/jikes/JikesCompiler.java
+++ b/plexus-compilers/plexus-compiler-jikes/src/main/java/org/codehaus/plexus/compiler/jikes/JikesCompiler.java
@@ -253,6 +253,11 @@ public class JikesCompiler
             args.add( "-verbose" );
         }
 
+        if (config.isWarningsAreErrors() )
+        {
+            args.add( "+Z" );
+        }
+
         if ( config.isDebug() )
         {
             args.add( "-g:lines" );

--- a/plexus-compilers/plexus-compiler-jikes/src/test/java/org/codehaus/plexus/compiler/jikes/JikesCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-jikes/src/test/java/org/codehaus/plexus/compiler/jikes/JikesCompilerTest.java
@@ -49,17 +49,20 @@ public class JikesCompilerTest
         setCompilerDeprecationWarnings( true );
     }
 
-    protected int expectedErrors()
+    @Override
+    protected int expectedErrors( boolean warningsAreErrors )
     {
         return 2;
     }
 
-    protected int expectedWarnings()
+    @Override
+    protected int expectedWarnings( boolean warningsAreErrors )
     {
         return 3;
     }
 
-    protected Collection<String> expectedOutputFiles()
+    @Override
+    protected Collection<String> expectedOutputFiles( boolean warningsAreErrors )
     {
         return Arrays.asList( new String[]{ "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
             "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class",


### PR DESCRIPTION
This adds a new boolean option to the CompilerConfiguration which turns
all warnings from the compiler into errors. For javac and derived
compilers, this is done by adding the -Werror flag in JDK 7 and later.