### PR TITLE
Import package uppercase

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/BAR/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/BAR/Baz.java
@@ -1,0 +1,4 @@
+package org.codehaus.BAR;
+
+public class Baz {
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
@@ -1,4 +1,0 @@
-package org.codehaus.bar;
-
-public class Baz {
-}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/bar/Baz.java
@@ -1,0 +1,4 @@
+package org.codehaus.bar;
+
+public class Baz {
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
@@ -1,6 +1,6 @@
 package org.codehaus.foo;
 
-import org.codehaus.bar.Baz;
+import org.codehaus.BAR.Baz;
 
 public class Import
 {

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
@@ -1,0 +1,8 @@
+package org.codehaus.foo;
+
+import org.codehaus.bar.Baz;
+
+public class Import
+{
+    public Baz baz;
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -66,7 +66,8 @@ public class EclipseCompilerTest
     protected Collection<String> expectedOutputFiles()
     {
         return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
-            "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class" } );
+                                             "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class",
+                                             "org/codehaus/foo/Import.class", "org/codehaus/bar/Baz.class" } );
     }
 
     // The test is fairly meaningless as we can not validate anything

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -67,7 +67,7 @@ public class EclipseCompilerTest
     {
         return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class", "org/codehaus/foo/ExternalDeps.class",
                                              "org/codehaus/foo/Person.class", "org/codehaus/foo/ReservedWord.class",
-                                             "org/codehaus/foo/Import.class", "org/codehaus/bar/Baz.class" } );
+                                             "org/codehaus/foo/Import.class", "org/codehaus/BAR/Baz.class" } );
     }
 
     // The test is fairly meaningless as we can not validate anything


### PR DESCRIPTION
There seems to be a problem where the eclipse compiler doesn't see classes in packages that have uppercase letters in them. I've personally seen errors when trying to use the compiler when my classes try to import classes under `org.xbill.DNS`. And there are the following stack overflow questions where people ran into the same error, and in both cases the classes reported as not being found are in packages with uppercase letters in them:
- http://stackoverflow.com/questions/17712838 (package: `com.Ostermiller`)
- http://stackoverflow.com/questions/17749375 (package: `org.omg.CORBA`)

This pull request includes three commits:

The first adds a test case for importing one class from another: `org.codehaus.foo.Import` imports `org.codehaus.bar.Baz`, and `EclipseCompilerTest` was adjusted to expect the two new class files. All tests pass with this commit.

The second commit just changes `org.codehaus.bar.Baz` to `org.codehaus.BAR.Baz`, and with this commit the test fails with the following errors in the out file:

```
----
/Users/user/projects/plexus-compiler/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
The import org.codehaus.BAR cannot be resolved
----
----
/Users/user/projects/plexus-compiler/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Import.java
Baz cannot be resolved to a type
----
```

This demonstrates that the failure is directly related to the casing of the package name.

The third commit replaces the use of `EclipseCompilerINameEnvironment` with `org.eclipse.jdt.internal.compiler.batch.FileSystem`. This fixes the broken test.
