### PR TITLE
#20 fix: When javac is used to compile the sources, verbose messages were ignored

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -93,6 +93,9 @@ public class JavacCompiler
     // see compiler.note.note in compiler.properties of javac sources
     private static final String[] NOTE_PREFIXES = { "Note: ", "\u6ce8: ", "\u6ce8\u610f\uff1a " };
 
+    // see compiler.misc.verbose in compiler.properties of javac sources
+    private static final String[] MISC_PREFIXES = { "[" };
+
     private static final Object LOCK = new Object();
 
     private static final String JAVAC_CLASSNAME = "com.sun.tools.javac.Main";
@@ -475,8 +478,6 @@ public class JavacCompiler
 
         CommandLineUtils.StringStreamConsumer out = new CommandLineUtils.StringStreamConsumer();
 
-        CommandLineUtils.StringStreamConsumer err = new CommandLineUtils.StringStreamConsumer();
-
         int returnCode;
 
         List<CompilerMessage> messages;
@@ -505,9 +506,9 @@ public class JavacCompiler
 
         try
         {
-            returnCode = CommandLineUtils.executeCommandLine( cli, out, err );
+            returnCode = CommandLineUtils.executeCommandLine( cli, out, out );
 
-            messages = parseModernStream( returnCode, new BufferedReader( new StringReader( err.getOutput() ) ) );
+            messages = parseModernStream( returnCode, new BufferedReader( new StringReader( out.getOutput() ) ) );
         }
         catch ( CommandLineException e )
         {
@@ -642,6 +643,11 @@ public class JavacCompiler
                 {
                     // skip, JDK 1.5 telling us deprecated APIs are used but -Xlint:deprecation isn't set
                 }
+                else if ( ( buffer.length() == 0 ) && isMisc( line ) )
+                {
+                    // verbose output was set
+                    errors.add( new CompilerMessage( line, CompilerMessage.Kind.OTHER ) );
+                }
                 else
                 {
                     buffer.append( line );
@@ -655,12 +661,22 @@ public class JavacCompiler
             errors.add( parseModernError( exitCode, buffer.toString() ) );
         }
     }
+    
+    private static boolean isMisc( String line )
+    {
+        return startsWithPrefix( line, MISC_PREFIXES );
+    }
 
     private static boolean isNote( String line )
     {
-        for ( int i = 0; i < NOTE_PREFIXES.length; i++ )
+        return startsWithPrefix( line, NOTE_PREFIXES );
+    }
+    
+    private static boolean startsWithPrefix( String line, String[] prefixes )
+    {
+        for ( int i = 0; i < prefixes.length; i++ )
         {
-            if ( line.startsWith( NOTE_PREFIXES[i] ) )
+            if ( line.startsWith( prefixes[i] ) )
             {
                 return true;
             }

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -27,6 +27,7 @@ package org.codehaus.plexus.compiler.javac;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -620,9 +621,15 @@ public class ErrorMessageParserTest
             + CRLF +
             "[total 654ms]" + CRLF +
             "4 warnings" + CRLF;
-        List<CompilerMessage> compilerErrors =
+        List<CompilerMessage> compilerMessages =
             JavacCompiler.parseModernStream( 0, new BufferedReader( new StringReader( errors ) ) );
-        assertEquals( "count", 3, compilerErrors.size() );
+        assertEquals( "count", 107, compilerMessages.size() );
+        List<CompilerMessage> compilerErrors = new ArrayList<CompilerMessage>( 3 );
+        for ( CompilerMessage message : compilerMessages ) {
+            if ( message.getKind() != CompilerMessage.Kind.OTHER ) {
+                compilerErrors.add( message );
+            }
+        }
         CompilerMessage error1 = compilerErrors.get( 0 );
         assertEquals( "file",
                       "C:\\commander\\pre\\ec\\ec-http\\src\\main\\java\\com\\electriccloud\\http\\HttpUtil.java",


### PR DESCRIPTION
PR for issue 20: adds `javac` output starting with `[` in the list of compiler messages with the kind `OTHER`.