### PR TITLE
Use ErrorProne .run() interface instead of static .compile() interface + bump to 2.0.13

### DIFF
--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
-      <version>2.0.5</version>
+      <version>2.0.13</version>
     </dependency>
   </dependencies>
 

--- a/plexus-compilers/plexus-compiler-javac-errorprone/src/main/java/org/codehaus/plexus/compiler/javac/errorprone/JavacCompilerWithErrorProne.java
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/src/main/java/org/codehaus/plexus/compiler/javac/errorprone/JavacCompilerWithErrorProne.java
@@ -112,7 +112,10 @@ public class JavacCompilerWithErrorProne
         public Class<?> loadClass( String name, boolean complete )
             throws ClassNotFoundException
         {
-            if ( name.contentEquals( CompilerResult.class.getName() ) )
+            // Classes loaded inside CompilerInvoker that need to reach back to the caller
+            if ( name.contentEquals( CompilerResult.class.getName() )
+                || name.contentEquals( CompilerMessage.class.getName() )
+                || name.contentEquals( CompilerMessage.Kind.class.getName() ) )
             {
                 return original.loadClass( name );
             }
@@ -216,7 +219,7 @@ public class JavacCompilerWithErrorProne
                 new ErrorProneCompiler.Builder() //
                     .listenToDiagnostics( new MessageListener( messages ) ) //
                     .build();
-            return new CompilerResult( compiler.compile( args ).isOK(), messages );
+            return new CompilerResult( compiler.run( args ).isOK(), messages );
         }
     }
 }


### PR DESCRIPTION
The plugin, as currently written, uses the static compile() method in ErrorProneCompiler. This ignores the intent of the code (to hitch up the CompilerMessage result).

I changed it to .run, which is the instance method we should have been calling, and added some plugin rejiggering.

The net change is that maven builds that fail with compile errors will reproduce the errors at the end of the compilation (previously, you'd only see them at the end of the compile).

We also bump to 2.0.13