### PR TITLE
Copy input map in setCustomCompilerArguments[AsMap]

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -426,14 +426,7 @@ public class CompilerConfiguration
     @Deprecated
     public void setCustomCompilerArguments( LinkedHashMap<String, String> customCompilerArguments )
     {
-        if ( customCompilerArguments == null )
-        {
-            this.customCompilerArguments = new ArrayList<Map.Entry<String,String>>();
-        }
-        else
-        {
-            this.customCompilerArguments = customCompilerArguments.entrySet();
-        }
+        setCustomCompilerArgumentsAsMap( customCompilerArguments );
     }
 
     /**
@@ -454,13 +447,10 @@ public class CompilerConfiguration
 
     public void setCustomCompilerArgumentsAsMap( Map<String, String> customCompilerArguments )
     {
-        if ( customCompilerArguments == null )
+        this.customCompilerArguments = new ArrayList<Map.Entry<String,String>>();
+        if ( customCompilerArguments != null )
         {
-            this.customCompilerArguments = new ArrayList<Map.Entry<String,String>>();
-        }
-        else
-        {
-            this.customCompilerArguments = customCompilerArguments.entrySet();
+            this.customCompilerArguments.addAll( customCompilerArguments.entrySet() );
         }
     }
     


### PR DESCRIPTION
Using `setCustomCompilerArgumentsAsMap` or `setCustomCompilerArguments` sets
the `customCompilerArguments` field to the maps entrySet, causing following add
operations to fail due to entry set being unmodifiable view. This should fix
the problem by creating a copy.