### PR TITLE
Add compiler arg to treat errors as warnings when using eclipse javac

### DIFF
--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -84,6 +84,11 @@ public abstract class AbstractCompilerTest
         return cp;
     }
 
+    protected void configureCompilerConfig( CompilerConfiguration compilerConfig )
+    {
+
+    }
+
     public void testCompilingSources()
         throws Exception
     {
@@ -182,6 +187,8 @@ public abstract class AbstractCompilerTest
             compilerConfig.addInclude( filename );
 
             compilerConfig.setForceJavacCompilerUse( this.forceJavacCompilerUse );
+
+            configureCompilerConfig( compilerConfig );
 
             //compilerConfig.setTargetVersion( "1.5" );
 

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -85,6 +85,7 @@ public class EclipseJavaCompiler
     // ----------------------------------------------------------------------
     // Compiler Implementation
     // ----------------------------------------------------------------------
+    boolean errorsAsWarnings = false;
 
     public CompilerResult performCompile( CompilerConfiguration config )
         throws CompilerException
@@ -180,7 +181,12 @@ public class EclipseJavaCompiler
 
         // compiler-specific extra options override anything else in the config object...
         Map<String, String> extras = cleanKeyNames( config.getCustomCompilerArgumentsAsMap() );
-
+        if( extras.containsKey( "errorsAsWarnings" ) )
+        {
+        	extras.remove( "errorsAsWarnings" );
+        	this.errorsAsWarnings = true;
+        }
+        
         settings.putAll( extras );
 
         if ( settings.containsKey( "properties" ) )
@@ -621,8 +627,15 @@ public class EclipseJavaCompiler
                     }
                     else
                     {
-                        hasErrors = true;
-                        errors.add( handleError( name, problem.getSourceLineNumber(), -1, problem.getMessage() ) );
+                    	if( errorsAsWarnings )
+                    	{
+                    		errors.add( handleWarning( name, problem ) );
+                    	}
+                    	else
+                    	{
+                    		hasErrors = true;
+                    		errors.add( handleError( name, problem.getSourceLineNumber(), -1, problem.getMessage() ) );
+                    	}
                     }
                 }
             }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerErrorsAsWarningsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerErrorsAsWarningsTest.java
@@ -1,0 +1,47 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.codehaus.plexus.compiler.AbstractCompilerTest;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+
+public class EclipseCompilerErrorsAsWarningsTest extends AbstractCompilerTest
+{
+
+    protected void configureCompilerConfig( CompilerConfiguration compilerConfig )
+    {
+        compilerConfig.addCompilerCustomArgument( "-errorsAsWarnings", "true" );
+    }
+
+    public void setUp() throws Exception
+    {
+        super.setUp();
+
+        setCompilerDebug( true );
+        setCompilerDeprecationWarnings( true );
+    }
+
+    protected String getRoleHint()
+    {
+        return "eclipse";
+    }
+
+    protected int expectedErrors()
+    {
+        return 0;
+    }
+
+    protected int expectedWarnings()
+    {
+        return 6;
+    }
+
+    protected Collection<String> expectedOutputFiles()
+    {
+        return Arrays.asList( new String[] { "org/codehaus/foo/Deprecation.class",
+            "org/codehaus/foo/ExternalDeps.class", "org/codehaus/foo/Person.class",
+            "org/codehaus/foo/ReservedWord.class", "org/codehaus/foo/Bad.class",
+            "org/codehaus/foo/UnknownSymbol.class", "org/codehaus/foo/RightClassname.class" } );
+    }
+}


### PR DESCRIPTION
The eclipse java compiler has a handy option to ignore errors in many cases, generating a method that throws a runtime exception if the code that couldn't be compiled is invoked. There are some situations I've run into where it's handy to have this ability when using maven to run the build... I've added a compiler arg that treats errors as warnings with the eclipse compiler.