### PR TITLE
Use latest ecj from official Eclipse release

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -19,9 +19,9 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.11.1.v20150902-1521</version>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>ecj</artifactId>
+      <version>3.12.3</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Eclipse now publish ecj on maven central in their release process. https://bugs.eclipse.org/bugs/show_bug.cgi?id=499019