### PR TITLE
Fix case-sensitivity issues

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/SourceCodeLocator.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/SourceCodeLocator.java
@@ -24,6 +24,7 @@ package org.codehaus.plexus.compiler.eclipse;
  * SOFTWARE.
  */
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -67,14 +68,20 @@ public class SourceCodeLocator
 
     private File findInRoots( String s )
     {
-        for ( String root : sourceRoots )
+        try
         {
-            File f = new File( root, s );
-
-            if ( f.exists() )
+            for ( String root : sourceRoots )
             {
-                return f;
+                File f = new File( root, s );
+
+                if ( f.exists() && f.getName().equals( f.getCanonicalFile().getName() ) )
+                {
+                    return f;
+                }
             }
+        } catch ( IOException e )
+        {
+            // Ignore
         }
 
         return null;


### PR DESCRIPTION
Originally here: https://github.com/sonatype/plexus-compiler/pull/29

We've deployed this patch very widely across users of our application to enable building on Windows in the case where we have a package that has the same name as a class.
