### PR TITLE
Better support for case insensitive filesystems.

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/SourceCodeLocator.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/SourceCodeLocator.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.io.File;
+import java.io.IOException;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
@@ -71,9 +72,16 @@ public class SourceCodeLocator
         {
             File f = new File( root, s );
 
-            if ( f.exists() )
+            try
             {
-                return f;
+                if ( f.exists() && f.getName().equals( f.getCanonicalFile().getName() ) )
+                {
+                    return f;
+                }
+            } catch ( IOException e )
+            {
+                throw new RuntimeException(
+                    "Error while getting the canonical path of '" + f.getAbsolutePath() + "'.", e );
             }
         }
 


### PR DESCRIPTION
Attempts to handle the case where a package and a class share the same name. Previously a combination of classes such as com.example.Foo and com.example.foo.Bar would cause an error on operating systems such as Windows. With this change the compilation proceeds as expected.