### PR TITLE
Only use the --release flag when javac supports it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 script: "mvn --show-version --errors --batch-mode -Prun-its clean verify"
 

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -332,7 +332,7 @@ public class JavacCompiler
             args.add( "-Werror" );
         }
 
-        if ( !StringUtils.isEmpty( config.getReleaseVersion() ) )
+        if ( supportsReleaseFlag() && !StringUtils.isEmpty( config.getReleaseVersion() ) )
         {
             args.add( "--release" );
             args.add( config.getReleaseVersion() );
@@ -460,6 +460,11 @@ public class JavacCompiler
 
         return v.startsWith( "1.7" ) || v.startsWith( "1.6" ) || v.startsWith( "1.5" ) || v.startsWith( "1.4" )
                 || v.startsWith( "1.3" ) || v.startsWith( "1.2" ) || v.startsWith( "1.1" ) || v.startsWith( "1.0" );
+    }
+
+    private static boolean supportsReleaseFlag()
+    {
+        return !System.getProperty("java.version").startsWith("1.");
     }
 
 

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -245,8 +245,16 @@ public abstract class AbstractJavacCompilerTest
 
         // releaseVersion
         compilerConfiguration.setReleaseVersion( "6" );
-        expectedArguments.add( "--release" );
-        expectedArguments.add( "6" );
+
+        if ( !System.getProperty( "java.version" ).startsWith( "1." ) ) {
+            expectedArguments.add( "--release" );
+            expectedArguments.add( "6" );
+        } else {
+            expectedArguments.add( "-target" );
+            expectedArguments.add( "1.1" );
+            expectedArguments.add( "-source" );
+            expectedArguments.add( "1.3" );
+        }
         
         internalTest( compilerConfiguration, expectedArguments );
     }


### PR DESCRIPTION
I believe the `--release` flag that was introduced in Java 9 should only be used when the Java version used to compile the project is 9+.

Context: all of our projects inherit from a so-called "master POM", where we define common behavior such as plugins and source/target versions. I tried to modify this master POM to include a default `maven.compiler.release` version, but it breaks the build for developers that are still using Java 1.8. Still, I think that this option is a nice addition for our developers that use Java 9 and want to make sure that projects targeting older versions of Java do not use APIs introduced in recent versions of Java.