### PR TITLE
Use the same JUnit version throughout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
         <artifactId>plexus-compiler-test</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+        <version>4.12</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -69,7 +75,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
-      <version>4.12</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Use the same JUnit version throughout

Without this change, most of the usages were resolving to 3.8.2