### PR TITLE
Parse Javac warnings

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -748,11 +748,9 @@ public class JavacCompiler
      */
     static CompilerMessage parseModernError( int exitCode, String error )
     {
-        StringTokenizer tokens = new StringTokenizer( error, ":" );
+        final StringTokenizer tokens = new StringTokenizer( error, ":" );
 
         boolean isError = exitCode != 0;
-
-        StringBuilder msgBuffer;
 
         try
         {
@@ -762,7 +760,7 @@ public class JavacCompiler
 
             boolean tokenIsAnInteger;
 
-            String file = null;
+            StringBuilder file = null;
 
             String currentToken = null;
 
@@ -772,11 +770,11 @@ public class JavacCompiler
                 {
                     if ( file == null )
                     {
-                        file = currentToken;
+                        file = new StringBuilder(currentToken);
                     }
                     else
                     {
-                        file = file + ':' + currentToken;
+                        file.append(':').append(currentToken);
                     }
                 }
 
@@ -797,23 +795,23 @@ public class JavacCompiler
             }
             while ( !tokenIsAnInteger );
 
-            String lineIndicator = currentToken;
+            final String lineIndicator = currentToken;
 
-            int startOfFileName = file.lastIndexOf( ']' );
+            final int startOfFileName = file.toString().lastIndexOf( ']' );
 
             if ( startOfFileName > -1 )
             {
-                file = file.substring( startOfFileName + 1 + EOL.length() );
+                file = new StringBuilder(file.substring(startOfFileName + 1 + EOL.length()));
             }
 
-            int line = Integer.parseInt( lineIndicator );
+            final int line = Integer.parseInt( lineIndicator );
 
-            msgBuffer = new StringBuilder();
+            final StringBuilder msgBuffer = new StringBuilder();
 
             String msg = tokens.nextToken( EOL ).substring( 2 );
 
             // Remove the 'warning: ' prefix
-            String warnPrefix = getWarnPrefix( msg );
+            final String warnPrefix = getWarnPrefix( msg );
             if ( warnPrefix != null )
             {
                 isError = false;
@@ -834,7 +832,7 @@ public class JavacCompiler
             
             do
             {
-                String msgLine = tokens.nextToken( EOL );
+                final String msgLine = tokens.nextToken( EOL );
 
                 if ( pointer != null )
                 {
@@ -859,18 +857,18 @@ public class JavacCompiler
 
             msgBuffer.append( EOL );
 
-            String message = msgBuffer.toString();
+            final String message = msgBuffer.toString();
 
-            int startcolumn = pointer.indexOf( "^" );
+            final int startcolumn = pointer.indexOf( "^" );
 
-            int endcolumn = context == null ? startcolumn : context.indexOf( " ", startcolumn );
+            int endcolumn = (context == null) ? startcolumn : context.indexOf(" ", startcolumn);
 
             if ( endcolumn == -1 )
             {
                 endcolumn = context.length();
             }
 
-            return new CompilerMessage( file, isError, line, startcolumn, line, endcolumn, message.trim() );
+            return new CompilerMessage(file.toString(), isError, line, startcolumn, line, endcolumn, message.trim() );
         }
         catch ( NoSuchElementException e )
         {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -74,6 +74,17 @@ public abstract class AbstractJavacCompilerTest
 
     protected int expectedWarnings()
     {
+        if (getJavaVersion().contains("1.8")){
+            // lots of new warnings about obsoletions for future releases
+            return 30;
+        }
+
+        if ( "1.6".compareTo( getJavaVersion() ) < 0 )
+        {
+            // with 1.7 some warning with bootstrap class path not set in conjunction with -source 1.3
+            return 9;
+        }
+
         return 2;
     }
 

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
@@ -25,21 +25,4 @@ public class JavaxToolsCompilerTest
     extends AbstractJavacCompilerTest
 {
     // no op default is to javax.tools if available
-
-    protected int expectedWarnings()
-    {
-        if (getJavaVersion().contains("1.8")){
-            // lots of new warnings about obsoletions for future releases
-            return 30;
-        }
-        else if ( "1.6".compareTo( getJavaVersion() ) < 0 )
-        {
-            // with 1.7 some warning with bootstrap class path not set in conjunction with -source 1.3
-            return 9;
-        }
-        else
-        {
-            return 2;
-        }
-    }
 }


### PR DESCRIPTION
This fixes the case presented in #37 and tests a couple other common cases.

It was implemented from the perspective of trying to make minimal changes to make the test case pass, so there may be other ways that warnings can be presented that would not be parsed correctly.  However, even if this is imperfect it is still a marked improvement over them not being parsed at all, and the test cases will be useful regardless.