### PR TITLE
Add the ability to specify --module-version argument for Java 9+

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -87,6 +87,11 @@ public class CompilerConfiguration
 
     private String sourceEncoding;
 
+    /**
+     * value of --module-version parameter in java 9+
+     */
+    private String moduleVersion;
+
     private Collection<Map.Entry<String,String>> customCompilerArguments = new ArrayList<Map.Entry<String,String>>();
 
     private boolean fork;
@@ -402,6 +407,16 @@ public class CompilerConfiguration
     public void setSourceEncoding( String sourceEncoding )
     {
         this.sourceEncoding = sourceEncoding;
+    }
+
+    public String getModuleVersion()
+    {
+        return moduleVersion;
+    }
+
+    public void setModuleVersion( String moduleVersion )
+    {
+        this.moduleVersion = moduleVersion;
     }
 
     public void addCompilerCustomArgument( String customArgument, String value )

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -372,6 +372,12 @@ public class JavacCompiler
             args.add( config.getSourceEncoding() );
         }
 
+        if ( !StringUtils.isEmpty( config.getModuleVersion() ) )
+        {
+            args.add( "--module-version" );
+            args.add( config.getModuleVersion() );
+        }
+
         for ( Map.Entry<String, String> entry : config.getCustomCompilerArgumentsEntries() )
         {
             String key = entry.getKey();

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -243,6 +243,31 @@ public abstract class AbstractJavacCompilerTest
         internalTest( compilerConfiguration, expectedArguments );
     }
 
+    public void testModuleVersion()
+    {
+        List<String> expectedArguments = new ArrayList<String>();
+
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+
+        // outputLocation
+        compilerConfiguration.setOutputLocation( "/output" );
+        expectedArguments.add( "-d" );
+        expectedArguments.add( new File( "/output" ).getAbsolutePath() );
+
+        // default source + target
+        expectedArguments.add( "-target" );
+        expectedArguments.add( "1.1" );
+        expectedArguments.add( "-source" );
+        expectedArguments.add( "1.3" );
+
+        // module version
+        compilerConfiguration.setModuleVersion( "1.2.0-SNAPSHOT" );
+        expectedArguments.add( "--module-version" );
+        expectedArguments.add( "1.2.0-SNAPSHOT" );
+
+        internalTest( compilerConfiguration, expectedArguments );
+    }
+
     public void testReleaseVersion()
     {
         List<String> expectedArguments = new ArrayList<String>();


### PR DESCRIPTION
This would enable the Maven Compiler Plugin to set the module version.