### PR TITLE
Fix tests failing failing when the test directory contains spaces

### DIFF
--- a/plexus-compiler-api/src/test/java/org/codehaus/plexus/compiler/util/scan/AbstractSourceInclusionScannerTest.java
+++ b/plexus-compiler-api/src/test/java/org/codehaus/plexus/compiler/util/scan/AbstractSourceInclusionScannerTest.java
@@ -19,6 +19,7 @@ package org.codehaus.plexus.compiler.util.scan;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Set;
 
@@ -71,6 +72,7 @@ public abstract class AbstractSourceInclusionScannerTest
     // ----------------------------------------------------------------------
 
     protected File getTestBaseDir()
+        throws URISyntaxException
     {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         URL markerResource = cl.getResource( TESTFILE_DEST_MARKER_FILE );
@@ -79,7 +81,7 @@ public abstract class AbstractSourceInclusionScannerTest
 
         if ( markerResource != null )
         {
-            File marker = new File( markerResource.getPath() );
+            File marker = new File( markerResource.toURI() );
 
             basedir = marker.getParentFile().getAbsoluteFile();
         }


### PR DESCRIPTION
`new File( markerResource.getPath() )` does not work when `markerResource` contains spaces or other characters that are URL encoded. The `File` constructor that takes URI as argument, takes care of those cases.