### PR TITLE
Fix issues in ecj compiler's error reporting

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjFailureException.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjFailureException.java
@@ -1,0 +1,19 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+/**
+ * @author <a href="mailto:jal@etc.to">Frits Jalvingh</a>
+ * Created on 22-4-18.
+ */
+public class EcjFailureException extends RuntimeException {
+    private final String ecjOutput;
+
+    public EcjFailureException(String ecjOutput) {
+        super("Failed to run the ecj compiler: " + ecjOutput);
+        this.ecjOutput = ecjOutput;
+    }
+
+    public String getEcjOutput()
+    {
+        return ecjOutput;
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -242,7 +242,8 @@ public class EclipseJavaCompiler
 
         // Compile! Send all errors to xml temp file.
         File errorF = null;
-        try {
+        try
+        {
             errorF = File.createTempFile("ecjerr-", ".xml");
 
             args.add("-log");
@@ -250,18 +251,23 @@ public class EclipseJavaCompiler
 
             // Add all sources.
             int argCount = args.size();
-            for(String source : config.getSourceLocations()) {
+            for(String source : config.getSourceLocations())
+            {
                 File srcFile = new File(source);
-                if(srcFile.exists()) {
-                    Set<String> ss = getSourceFilesForSourceRoot( config, source );
+                if(srcFile.exists())
+                {
+                    Set<String> ss = getSourceFilesForSourceRoot(config, source);
                     args.addAll(ss);
                 }
             }
             args.addAll(extraSourceDirs);
-            if(args.size() == argCount) {
+            if(args.size() == argCount)
+            {
                 //-- Nothing to do -> bail out
                 return new CompilerResult(true, Collections.EMPTY_LIST);
             }
+
+            getLogger().debug("ecj command line: " + args);
 
             StringWriter sw = new StringWriter();
             PrintWriter devNull = new PrintWriter(sw);
@@ -298,18 +304,22 @@ public class EclipseJavaCompiler
 
             List<CompilerMessage> messageList;
             boolean hasError = false;
-            if(errorF.length() < 80) {
-                throw new IOException("Failed to run the ECJ compiler:\n" + sw.toString());
+            if(errorF.length() < 80)
+            {
+                throw new EcjFailureException(sw.toString());
             }
             messageList = new EcjResponseParser().parse(errorF, errorsAsWarnings);
 
-            for(CompilerMessage compilerMessage : messageList) {
-                if(compilerMessage.isError()) {
+            for(CompilerMessage compilerMessage : messageList)
+            {
+                if(compilerMessage.isError())
+                {
                     hasError = true;
                     break;
                 }
             }
-            if(! hasError && ! success && ! errorsAsWarnings) {
+            if(!hasError && !success && !errorsAsWarnings)
+            {
                 CompilerMessage.Kind kind = errorsAsWarnings ? CompilerMessage.Kind.WARNING : CompilerMessage.Kind.ERROR;
 
                 //-- Compiler reported failure but we do not seem to have one -> probable exception
@@ -325,8 +335,9 @@ public class EclipseJavaCompiler
                     messageList.add(cm);
                 }
             }
-            return new CompilerResult(! hasError || errorsAsWarnings, messageList);
-
+            return new CompilerResult(!hasError || errorsAsWarnings, messageList);
+        } catch(EcjFailureException x) {
+            throw x;
         } catch(Exception x) {
             throw new RuntimeException(x);				// sigh
         } finally {

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -310,8 +310,10 @@ public class EclipseJavaCompiler
                 }
             }
             if(! hasError && ! success && ! errorsAsWarnings) {
+                CompilerMessage.Kind kind = errorsAsWarnings ? CompilerMessage.Kind.WARNING : CompilerMessage.Kind.ERROR;
+
                 //-- Compiler reported failure but we do not seem to have one -> probable exception
-                CompilerMessage cm = new CompilerMessage("[ecj] The compiler reported an error but has not written it to its logging", CompilerMessage.Kind.ERROR);
+                CompilerMessage cm = new CompilerMessage("[ecj] The compiler reported an error but has not written it to its logging", kind);
                 messageList.add(cm);
                 hasError = true;
 
@@ -319,11 +321,11 @@ public class EclipseJavaCompiler
                 String stdout = getLastLines(sw.toString(), 5);
                 if(stdout.length() > 0)
                 {
-                    cm = new CompilerMessage("[ecj] The following line(s) might indicate the issue:\n" + stdout, CompilerMessage.Kind.ERROR);
+                    cm = new CompilerMessage("[ecj] The following line(s) might indicate the issue:\n" + stdout, kind);
                     messageList.add(cm);
                 }
             }
-            return new CompilerResult(! hasError, messageList);
+            return new CompilerResult(! hasError || errorsAsWarnings, messageList);
 
         } catch(Exception x) {
             throw new RuntimeException(x);				// sigh
@@ -345,9 +347,6 @@ public class EclipseJavaCompiler
         int index = text.length();
         while(index > 0) {
             int before = text.lastIndexOf('\n', index - 1);
-//            if(before == -1) {
-//                before = 0;
-//            }
 
             if(before + 1 < index) {                        // Non empty line?
                 lineList.add(text.substring(before + 1, index));

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
@@ -1,0 +1,76 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.compiler.Compiler;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.codehaus.plexus.util.FileUtils;
+import org.junit.Assert;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:jal@etc.to">Frits Jalvingh</a>
+ * Created on 22-4-18.
+ */
+public class EclipseCompilerDashedArgumentsTest extends PlexusTestCase {
+
+    public static final String BAD_DOUBLEDASH_OPTION = "--grubbelparkplace";
+
+    private CompilerConfiguration getConfig() throws Exception {
+        String sourceDir = getBasedir() + "/src/test-input/src/main";
+
+        List<String> filenames = FileUtils.getFileNames( new File( sourceDir ), "**/*.java", null, false, true );
+        Collections.sort( filenames );
+        Set<File> files = new HashSet<>();
+        for(String filename : filenames)
+        {
+            files.add(new File(filename));
+        }
+
+        CompilerConfiguration compilerConfig = new CompilerConfiguration();
+        compilerConfig.setDebug(false);
+        compilerConfig.setShowDeprecation(false);
+
+//            compilerConfig.setClasspathEntries( getClasspath() );
+        compilerConfig.addSourceLocation( sourceDir );
+        compilerConfig.setOutputLocation( getBasedir() + "/target/eclipse/classes");
+        FileUtils.deleteDirectory( compilerConfig.getOutputLocation() );
+//        compilerConfig.addInclude( filename );
+        compilerConfig.setForceJavacCompilerUse(false);
+        compilerConfig.setSourceFiles(files);
+
+        compilerConfig.setTargetVersion("1.8");
+        compilerConfig.setSourceVersion("1.8");
+        return compilerConfig;
+    }
+
+    /**
+     * Start the eclipse compiler with a bad option that has two dashes. It should abort, and the error
+     * message should show the actual bad option with two dashes. This ensures that both dashes are passed
+     * to the compiler proper.
+     *
+     * This also tests that con-compile errors are shown properly, as the error caused by
+     * the invalid option is not part of the error output but part of the data sent to stdout/stderr.
+     */
+    public void testDoubleDashOptionsArePassedWithTwoDashes() throws Exception
+    {
+        Compiler compiler = (Compiler) lookup( Compiler.ROLE, "eclipse" );
+        CompilerConfiguration config = getConfig();
+        config.addCompilerCustomArgument(BAD_DOUBLEDASH_OPTION, "b0rk3d");
+
+        try
+        {
+            compiler.performCompile(config);
+            Assert.fail("Expected an exception to be thrown");
+        } catch(EcjFailureException x) {
+            String ecjOutput = x.getEcjOutput();
+            Assert.assertTrue("The output should report the failure with two dashes: " + ecjOutput
+                    , ecjOutput.contains(BAD_DOUBLEDASH_OPTION) && ! ecjOutput.contains("-" + BAD_DOUBLEDASH_OPTION)
+            );
+        }
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
@@ -1,5 +1,29 @@
 package org.codehaus.plexus.compiler.eclipse;
 
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.compiler.Compiler;
 import org.codehaus.plexus.compiler.CompilerConfiguration;


### PR DESCRIPTION
This fixes the following issues with newer ecj compiler versions, like 4.7.3 and 4.8M6:

* the compiler reports some errors as exceptions, and these are not written to its compile output log. For instance errors like "internal compiler error" and errors that occur with the --add-modules options are handled as exceptions inside the compiler and these are just logged on stdout. This fix tries to obtain the error by scanning the last lines of output when no other error has been found. It then reports it as follows:

        [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project to.etc.alg: Compilation failure: Compilation failure: 
        [ERROR] [ecj] The compiler reported an error but has not written it to its logging
        [ERROR] [ecj] The following line(s) might indicate the issue:
        [ERROR] invalid module name: org.w3c.dom

* the compiler expects some parameters with a double dash, like --add-modules. It was not possible to pass these kinds of parameters before: they were always manged, partially because the compiler mojo does unspeakable things to &lt;compilerArguments&gt; ;) But reading its source code revealed that there is a way to get the arguments in properly: by using the &lt;compilerArgs&gt; option with each part of an option passed separately using &lt;arg&gt;. So to pass the above --add-modules option it should be valid to write:

        <compilerArgs>
          <arg>--add-modules</arg>
          <arg>java.se.ee</arg>
        </compilerArgs>

    This now works correctly as far as passing the arguments is concerned (there appear to be bugs in the ecj compiler where it does not accept valid modules, this seems fixed in 4.8M6 though).

* the compiler API sometimes does a System.exit() when it does not like things, by default 8-/. I added the parameter -noExit to the command line to tell it that System.exit() is not at all appreciated.

These fixes should at least allow ecj to be used as a java 9 compiler.
