### PR TITLE
report initialization of boot layer error messages

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -675,9 +675,17 @@ public class JavacCompiler
             {
                 // javac output not detected by other parsing
                 // maybe better to ignore only the summary an mark the rest as error
-                if (buffer.length() > 0 && buffer.toString().startsWith("javac:"))
+                String bufferAsString = buffer.toString();
+                if ( buffer.length() > 0 )
                 {
-                    errors.add( new CompilerMessage( buffer.toString(), CompilerMessage.Kind.ERROR ) );
+                    if ( bufferAsString.startsWith("javac:"))
+                    {
+                        errors.add( new CompilerMessage( bufferAsString, CompilerMessage.Kind.ERROR ) );
+                    }
+                    else if ( bufferAsString.startsWith("Error occurred during initialization of boot layer"))
+                    {
+                        errors.add( new CompilerMessage( bufferAsString, CompilerMessage.Kind.OTHER ) );
+                    }
                 }
                 return errors;
             }

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -894,6 +894,18 @@ public class ErrorMessageParserTest
               ".tools.javac.Main.main(Main.java:43)" + EOL));
     }
 
+    public void testJvmError() throws Exception
+    {
+        String out = "Error occurred during initialization of boot layer" + EOL +
+        		"java.lang.module.FindException: Module java.xml.bind not found";
+
+        List<CompilerMessage> compilerErrors = JavacCompiler.parseModernStream( 1, new BufferedReader( new StringReader( out ) ));
+
+        assertNotNull( compilerErrors );
+
+        assertEquals( 1, compilerErrors.size() );
+    }
+
     private static void assertEquivalent(CompilerMessage expected, CompilerMessage actual){
         assertEquals("Message did not match", expected.getMessage(), actual.getMessage());
         assertEquals("Kind did not match", expected.getKind(), actual.getKind());


### PR DESCRIPTION
This adds support for reporting initialization of boot layer error
messages that occur when the `javac` JVM cannot be started. In that case
output will contain message like:

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Module java.xml.bind not found
```

This message currently would be lost, i.e. the only message reported
when used in `maven-compiler-plugin` would be:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project ...: Compilation failure -> [Help 1]
```

Now an `INFO` message would appear above this as:
```
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ bom-generator-maven-plugin ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 5 source files to .../target/classes
[INFO] Error occurred during initialization of boot layer
java.lang.module.FindException: Module java.xml.bind not found
```

Making the error message outputted by `javac` at least visible for
troubleshooting.