### PR TITLE
upgrade ecj compiler to latest version

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -19,9 +19,9 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.15.1</version>
+      <version>4.6.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hi,
I upgraded ecj version to the latest version. The ecj maven artifact group has changed starting from 3.3.1 (from **org.eclipse.jdt** to **org.eclipse.jdt.core.compiler** ). This prevents overwriting the dependency and use the latest version.
