### PR TITLE
Fixes a bug where errors remain in the buffer without being captured

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -690,6 +690,11 @@ public class JavacCompiler
                     {
                         errors.add( new CompilerMessage( bufferAsString, CompilerMessage.Kind.OTHER ) );
                     }
+                    else if ( hasPointer )
+                    {
+                        //A compiler message remains in buffer at end of parse stream
+                        errors.add( parseModernError( exitCode, bufferAsString ) );
+                    }
                 }
                 return errors;
             }

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -906,6 +906,59 @@ public class ErrorMessageParserTest
         assertEquals( 1, compilerErrors.size() );
     }
 
+    public void testBadSourceFileError() throws Exception
+    {
+        String out = "/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java:12: error: cannot access Cls2\n" +
+                "    Cls2 tvar;\n" +
+                "    ^\n" +
+                "  bad source file: /MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls2.java\n" +
+                "    file does not contain class ch.pecunifex.x.Cls2\n" +
+                "    Please remove or make sure it appears in the correct subdirectory of the sourcepath.";
+
+        List<CompilerMessage> compilerErrors = JavacCompiler.parseModernStream( 1, new BufferedReader( new StringReader( out ) ));
+
+        assertNotNull( compilerErrors );
+
+        assertEquals( 1, compilerErrors.size() );
+
+        final CompilerMessage message = compilerErrors.get( 0 );
+        validateBadSourceFile(message);
+    }
+
+    public void testWarningFollowedByBadSourceFileError() throws Exception
+    {
+        String out = "/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java:3: warning: FontDesignMetrics is internal proprietary API and may be removed in a future release\n" +
+                "import sun.font.FontDesignMetrics;\n" +
+                "               ^\n" +
+                "/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java:12: error: cannot access Cls2\n" +
+                "    Cls2 tvar;\n" +
+                "    ^\n" +
+                "  bad source file: /MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls2.java\n" +
+                "    file does not contain class ch.pecunifex.x.Cls2\n" +
+                "    Please remove or make sure it appears in the correct subdirectory of the sourcepath.";
+
+        List<CompilerMessage> compilerErrors = JavacCompiler.parseModernStream( 1, new BufferedReader( new StringReader( out ) ));
+
+        assertNotNull( compilerErrors );
+
+        assertEquals( 2, compilerErrors.size() );
+
+        final CompilerMessage firstMessage = compilerErrors.get( 0 );
+        assertEquals( "Is a Warning", CompilerMessage.Kind.WARNING, firstMessage.getKind() );
+        assertEquals( "On Correct File","/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java", firstMessage.getFile() );
+        assertEquals( "Internal API Warning", "FontDesignMetrics is internal proprietary API and may be removed in a future release", firstMessage.getMessage() );
+
+        final CompilerMessage secondMessage = compilerErrors.get( 1 );
+        validateBadSourceFile(secondMessage);
+    }
+
+    private void validateBadSourceFile(CompilerMessage message)
+    {
+        assertEquals( "Is an Error", CompilerMessage.Kind.ERROR, message.getKind() );
+        assertEquals( "On Correct File","/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java", message.getFile() );
+        assertTrue( "Message starts with access Error", message.getMessage().startsWith("error: cannot access Cls2") );
+    }
+
     private static void assertEquivalent(CompilerMessage expected, CompilerMessage actual){
         assertEquals("Message did not match", expected.getMessage(), actual.getMessage());
         assertEquals("Kind did not match", expected.getKind(), actual.getKind());


### PR DESCRIPTION
Whilst investigating MTOOLCHAINS-19 I traced the source of the bug to the parsing of Error messages in JavacCompiler.

When the compiler has an error for an access/bad source file, this is not parsed and returned in the List<CompilerMessage>

After discussion with @rfscholte on #62 the fix was too specific. This fix is an attempt to ensure any error remaining in the buffer at the end of the parse will be reflected into the output messages.