### PR TITLE
Add support for failOnWarning in eclipse compiler.

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.15.1</version>
+      <version>3.19.0</version>
     </dependency>
   </dependencies>
 

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -123,6 +123,11 @@ public class EclipseJavaCompiler
         {
             args.add("-parameters");
         }
+        
+        if(config.isFailOnWarning())
+        {
+        	args.add("-failOnWarning");
+        }
 
         // Set Eclipse-specific options
         // compiler-specific extra options override anything else in the config object...

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerFailOnWarningsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerFailOnWarningsTest.java
@@ -1,0 +1,41 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+import org.codehaus.plexus.compiler.AbstractCompilerTest;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class EclipseCompilerFailOnWarningsTest extends AbstractCompilerTest
+{
+
+    protected void configureCompilerConfig( CompilerConfiguration compilerConfig )
+    {
+        compilerConfig.setFailOnWarning(true);
+    }
+
+    protected String getRoleHint()
+    {
+        return "eclipse";
+    }
+
+    protected int expectedErrors()
+    {
+        return 6;
+    }
+
+    protected int expectedWarnings()
+    {
+        return 1;
+    }
+
+    protected Collection<String> expectedOutputFiles()
+    {
+        return Arrays.asList( new String[] {
+            "org/codehaus/foo/Deprecation.class",
+            "org/codehaus/foo/ExternalDeps.class",
+            "org/codehaus/foo/Person.class",
+            "org/codehaus/foo/ReservedWord.class"
+        });
+    }
+}


### PR DESCRIPTION
This required updating ecj to 3.19.0 version which contains fix for
that.