### PR TITLE
Bump error prone

### DIFF
--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
2.3.4 is the latest supported by p-c-j-ep, as after https://github.com/google/error-prone/commit/9eb414cc1 ErrorProneCompiler is no longer delivered with EP, and is not present in next version 2.4.0. (Shown in builds of #76.)