### PR TITLE
Rename method, now that EA of JDK 16 is available

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -216,7 +216,7 @@ public class EclipseJavaCompiler
 
         // Annotation processors defined?
         List<String> extraSourceDirs = new ArrayList<>();
-        if(!isPreJava16(config)) {
+        if(!isPreJava1_6(config)) {
             //now add jdk 1.6 annotation processing related parameters
             String[] annotationProcessors = config.getAnnotationProcessors();
             List<String> processorPathEntries = config.getProcessorPathEntries();
@@ -550,7 +550,7 @@ public class EclipseJavaCompiler
         warns.append(s);
     }
 
-    private boolean isPreJava16(CompilerConfiguration config) {
+    private boolean isPreJava1_6(CompilerConfiguration config) {
         String s = config.getSourceVersion();
         if ( s == null )
         {


### PR DESCRIPTION
Seems that travis has issue with delivering check status:
:heavy_check_mark: [705367362](https://travis-ci.org/github/codehaus-plexus/plexus-compiler/builds/705367362)