### PR TITLE
CSharp compiler: fix role

### DIFF
--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
@@ -17,6 +17,7 @@ package org.codehaus.plexus.compiler.csharp;
  */
 
 import org.codehaus.plexus.compiler.AbstractCompiler;
+import org.codehaus.plexus.compiler.Compiler;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.codehaus.plexus.compiler.CompilerException;
 import org.codehaus.plexus.compiler.CompilerMessage;


### PR DESCRIPTION
The role of the _CSharpCompiler_ was _java.lang.Compiler_ due to a missing import. Because of that the compiler could not be discovered. Fix it by adding the missing import.
 