### PR TITLE
Add new showLint compiler configuration

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -68,7 +68,9 @@ public class CompilerConfiguration
     private String debugLevel;
 
     private boolean showWarnings = true;
-    
+
+    private String warnings;
+
     /**
      * -Werror argument as supported since Java 1.7
      */
@@ -79,7 +81,7 @@ public class CompilerConfiguration
     private String sourceVersion;
 
     private String targetVersion;
-    
+
     /**
      * value of -release parameter in java 9+
      */
@@ -354,16 +356,26 @@ public class CompilerConfiguration
         return showDeprecation;
     }
 
+    public String getWarnings()
+    {
+        return warnings;
+    }
+
+    public void setShowLint( String warnings )
+    {
+        this.warnings = warnings;
+    }
+
     public void setShowDeprecation( boolean showDeprecation )
     {
         this.showDeprecation = showDeprecation;
     }
-    
+
     public boolean isFailOnWarning()
     {
         return failOnWarning;
     }
-    
+
     public void setFailOnWarning( boolean failOnWarnings )
     {
         this.failOnWarning = failOnWarnings;
@@ -388,7 +400,7 @@ public class CompilerConfiguration
     {
         this.targetVersion = targetVersion;
     }
-    
+
     public String getReleaseVersion()
     {
         return releaseVersion;
@@ -451,7 +463,7 @@ public class CompilerConfiguration
 
     /**
      * Get all unique argument keys and their value. In case of duplicate keys, last one added wins.
-     * 
+     *
      * @return
      * @see CompilerConfiguration#getCustomCompilerArgumentsEntries()
      */
@@ -473,10 +485,10 @@ public class CompilerConfiguration
             this.customCompilerArguments.addAll( customCompilerArguments.entrySet() );
         }
     }
-    
+
     /**
      * In case argument keys are not unique, this will return all entries
-     * 
+     *
      * @return
      */
     public Collection<Map.Entry<String,String>> getCustomCompilerArgumentsEntries()

--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-compiler</artifactId>
-      <version>2.8.9-SNAPSHOT</version>
+    <groupId>org.codehaus.plexus</groupId>
+    <artifactId>plexus-compiler</artifactId>
+    <version>2.8.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-its</artifactId>

--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.codehaus.plexus</groupId>
-    <artifactId>plexus-compiler</artifactId>
-    <version>2.8.9-SNAPSHOT</version>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-compiler</artifactId>
+      <version>2.8.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>plexus-compiler-its</artifactId>

--- a/plexus-compiler-its/src/main/it/simple-javac/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-javac/pom.xml
@@ -55,6 +55,11 @@
           </compilerArgs>
         </configuration>
         <dependencies>
+            <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-api</artifactId>
+            <version>@pom.version@</version>
+          </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac</artifactId>

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -129,7 +129,10 @@ public class EclipseJavaCompiler
         }
         else
         {
-            StringBuilder warns = new StringBuilder();
+            String warnings = config.getWarnings();
+            StringBuilder warns = StringUtils.isEmpty(warnings)
+                    ? new StringBuilder()
+                    : new StringBuilder(warnings).append(',');
 
             if ( config.isShowDeprecation() )
             {

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -235,7 +235,7 @@ public class JavacCompiler
 
             args.add( getPathString( classpathEntries ) );
         }
-        
+
         List<String> modulepathEntries = config.getModulepathEntries();
         if ( modulepathEntries != null && !modulepathEntries.isEmpty() )
         {
@@ -343,8 +343,15 @@ public class JavacCompiler
         if ( !config.isShowWarnings() )
         {
             args.add( "-nowarn" );
+        } else
+        {
+            String warnings = config.getWarnings();
+            if (StringUtils.isNotEmpty(warnings))
+            {
+                args.add("-Xlint:" +  warnings);
+            }
         }
-        
+
         if ( config.isFailOnWarning() )
         {
             args.add( "-Werror" );
@@ -380,7 +387,7 @@ public class JavacCompiler
             {
                 args.add( "-source" );
                 args.add( config.getSourceVersion() );
-            }            
+            }
         }
 
 
@@ -710,13 +717,13 @@ public class JavacCompiler
         String line;
 
         StringBuilder buffer = new StringBuilder();
-        
+
         boolean hasPointer = false;
 
         while ( true )
         {
             line = input.readLine();
-            
+
             if ( line == null )
             {
                 // javac output not detected by other parsing
@@ -760,10 +767,10 @@ public class JavacCompiler
             {
                 // add the error bean
                 errors.add( parseModernError( exitCode, buffer.toString() ) );
-                
+
                 // reset for next error block
                 buffer = new StringBuilder(); // this is quicker than clearing it
-                
+
                 hasPointer = false;
             }
 
@@ -791,14 +798,14 @@ public class JavacCompiler
 
                 buffer.append( EOL );
             }
-            
+
             if ( line.endsWith( "^" ) )
             {
                 hasPointer = true;
             }
         }
     }
-    
+
     private static boolean isMisc( String line )
     {
         return startsWithPrefix( line, MISC_PREFIXES );
@@ -808,7 +815,7 @@ public class JavacCompiler
     {
         return startsWithPrefix( line, NOTE_PREFIXES );
     }
-    
+
     private static boolean startsWithPrefix( String line, String[] prefixes )
     {
         for ( int i = 0; i < prefixes.length; i++ )
@@ -909,9 +916,9 @@ public class JavacCompiler
             msgBuffer.append( EOL );
 
             String context = tokens.nextToken( EOL );
-            
+
             String pointer = null;
-            
+
             do
             {
                 final String msgLine = tokens.nextToken( EOL );


### PR DESCRIPTION
Adds the ability to configure additional non-default compiler warnings and lint. To be used for the javac -Xlint or similar features of the ECJ compiler. The option will be added to the maven-java-compiler plugin (which depends upon plexus-compiler)