### PR TITLE
fix: --processor-module-path behaviour with absolut sourcepath

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -291,7 +291,7 @@ public class JavacCompiler
             }
             if ( config.getProcessorPathEntries() != null && !config.getProcessorPathEntries().isEmpty() ) {
 
-                if(!isPreJava9(config) && Arrays.asList(sourceFiles).contains("module-info.java")){
+                if(!isPreJava9(config) && containsModuleInfo(sourceFiles)){
                     args.add( "--processor-module-path" );
 
                 } else {
@@ -531,6 +531,19 @@ public class JavacCompiler
                 || v.startsWith( "1.3" ) || v.startsWith( "1.2" ) || v.startsWith( "1.1" ) || v.startsWith( "1.0" );
     }
 
+    /**
+     * Check if a list of paths contains a module-info.java file
+     * @param sourceFiles list of source files
+     * @return true if a module-info.java is contained
+     */
+    private static boolean containsModuleInfo(String[] sourceFiles){
+        for (String sourceFile : sourceFiles) {
+            if (sourceFile.endsWith("module-info.java")) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private static boolean suppressSource( CompilerConfiguration config )
     {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -301,7 +301,7 @@ public abstract class AbstractJavacCompilerTest
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        final String[] source = {"module-info.java"};
+        final String[] source = {"/src/main/one/module-info.java"};
 
         // outputLocation
         compilerConfiguration.setOutputLocation( "/output" );


### PR DESCRIPTION
Extended module-info.java check inside absolute sourcepath, previous those where ignored.

This is related to #67