### PR TITLE
Fix AspectJ basics

### DIFF
--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -39,7 +39,8 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <debug>true</debug>
+              <debug>false</debug>
+              <streamLogsOnFailures>true</streamLogsOnFailures>
               <projectsDirectory>src/main/it</projectsDirectory>
               <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
               <postBuildHookScript>verify</postBuildHookScript>

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/invoker.properties
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 1.8+
+invoker.goals = clean test
+#invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.compiler.it</groupId>
+  <artifactId>aspectj-compiler</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <compilerId>aspectj</compilerId>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-api</artifactId>
+            <version>@pom.version@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-aspectj</artifactId>
+            <version>@pom.version@</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+      <version>@aspectj.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/Application.java
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/Application.java
@@ -1,0 +1,12 @@
+package org.acme;
+
+public class Application {
+  public static void main(String[] args) {
+    System.out.println("Running application");
+    new Application().greet(args[0]);
+  }
+
+  public String greet(String name) {
+    return "Hello " + name;
+  }
+}

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/MyAnnotationDrivenAspect.aj
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/MyAnnotationDrivenAspect.aj
@@ -1,0 +1,13 @@
+package org.acme;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Aspect
+public class MyAnnotationDrivenAspect {
+  @Before("execution(static * *(..)) && within(Application)")
+  public void myAdvice(JoinPoint joinPoint) {
+    System.out.println(joinPoint);
+  }
+}

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/MyNativeAspect.aj
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/MyNativeAspect.aj
@@ -1,0 +1,7 @@
+package org.acme;
+
+public aspect MyNativeAspect {
+  before() : execution(!static * *(..)) && within(Application) {
+    System.out.println(thisJoinPoint);
+  }
+}

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/do-not-try-to-compile.txt
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/main/java/org/acme/do-not-try-to-compile.txt
@@ -1,0 +1,7 @@
+The Apache Maven Compiler (MC) API only allows a single source file extension, such as '.java'.
+The AspectJ Compiler (AJC) should consider two default extensions, though: '.java' and '.aj'.
+In order to achieve that, the Plexus AJC component tells MC to give it all files,
+subsequently filtering for those two extensions.
+
+The purpose of this file is to make sure that even though MC finds it in the source folder,
+Plexus AJC filters it out and AJC does not try to compile it. 

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/test/java/org/acme/ApplicationTest.java
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/test/java/org/acme/ApplicationTest.java
@@ -1,0 +1,19 @@
+package org.acme;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ApplicationTest {
+  @Test
+  public void testGreet() {
+    assertEquals("Hello Jane", new Application().greet("Jane"));
+  }
+
+  @Test
+  public void testMain() {
+    Application.main(new String[] { "Joe" });
+    assertTrue(true);
+  }
+}

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/src/test/java/org/acme/TestAspect.java
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/src/test/java/org/acme/TestAspect.java
@@ -1,0 +1,13 @@
+package org.acme;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Aspect
+public class TestAspect {
+  @Before("call(* *(..)) && !within(TestAspect)")
+  public void beforeCall(JoinPoint joinPoint) {
+    System.out.println(joinPoint);
+  }
+}

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/verify.groovy
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def logFile = new File( basedir, 'build.log' )
+assert logFile.exists()
+content = logFile.text.normalize()
+
+def junitLog = """Running org.acme.ApplicationTest
+call(String org.acme.Application.greet(String))
+execution(String org.acme.Application.greet(String))
+call(void org.junit.Assert.assertEquals(Object, Object))
+call(void org.acme.Application.main(String[]))
+execution(void org.acme.Application.main(String[]))
+Running application
+execution(String org.acme.Application.greet(String))
+call(void org.junit.Assert.assertTrue(boolean))
+Tests run: 2, Failures: 0, Errors: 0, Skipped: 0""".normalize()
+
+assert content.contains( junitLog )

--- a/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
@@ -38,7 +38,8 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>@junit.version@</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/plexus-compiler-its/src/main/it/simple-javac/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-javac/pom.xml
@@ -37,7 +37,8 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>@junit.version@</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -13,10 +13,6 @@
   <name>Plexus AspectJ Compiler</name>
   <description>AspectJ Compiler support for Plexus Compiler component.</description>
 
-  <properties>
-    <aspectj.version>1.9.6</aspectj.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
@@ -3,7 +3,6 @@ package org.codehaus.plexus.compiler.ajc;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.codehaus.plexus.compiler.AbstractCompilerTest;
@@ -24,40 +23,19 @@ public class AspectJCompilerTest
         return "aspectj";
     }
 
-    protected int expectedErrors()
-    {
-        // olamy well I agree it's hackhish but I don't want to waste too much time with aspectj which is probably
-        // not used a lot anymore...
-        String javaVersion = getJavaVersion();
-        if (javaVersion.equals( "11" ))
-        {
-            return 11;
-        }
-        return 1;
-    }
-
     protected Collection<String> expectedOutputFiles()
     {
-        String javaVersion = System.getProperty( "java.version" );
-        // olamy well I agree it's hackhish but I don't want to waste too much time with aspectj which is probably
-        // not used a lot anymore...
-//        if (javaVersion.startsWith( "9" ) || javaVersion.startsWith( "10" ))
-//        {
-//            return Collections.emptyList();
-//        }
-        return Arrays.asList( new String[]{ "org/codehaus/foo/ExternalDeps.class", "org/codehaus/foo/Person.class" } );
+        return Arrays.asList( "org/codehaus/foo/ExternalDeps.class", "org/codehaus/foo/Person.class" );
     }
 
     protected List<String> getClasspath()
         throws Exception
     {
-        List<String> cp = super.getClasspath();
-
-        File localArtifactPath =
-            getLocalArtifactPath( "org.aspectj", "aspectjrt", System.getProperty( "aspectj.version" ), "jar" );
-        cp.add( localArtifactPath.getAbsolutePath() );
-
-        return cp;
+        List<String> classpath = super.getClasspath();
+        String aspectjVersion = System.getProperty( "aspectj.version" );
+        File aspectjRuntime = getLocalArtifactPath( "org.aspectj", "aspectjrt", aspectjVersion, "jar" );
+        classpath.add( aspectjRuntime.getAbsolutePath() );
+        return classpath;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2020-08-24T00:30:49Z</project.build.outputTimestamp>
     <junit.version>4.13.2</junit.version>
+    <aspectj.version>1.9.7.M3</aspectj.version>
     <errorprone.version>2.6.0</errorprone.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <javaVersion>7</javaVersion>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2020-08-24T00:30:49Z</project.build.outputTimestamp>
+    <junit.version>4.13.2</junit.version>
     <errorprone.version>2.6.0</errorprone.version>
   </properties>
 
@@ -80,7 +81,7 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <scope>test</scope>
-        <version>4.13.2</version>
+        <version>${junit.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Fix basic AspectJ compiler functionality + add integration test

This is a first, basic step into improving AspectJ support for Plexus Compiler. It looks like nobody ever noticed, that target and release parameters are not forwarded to AJC, resulting in all class files being compiled to Java 1.2 target. I.e. that annotation-based @<!-- -->AspectJ syntax was completely unsupported before. Since Plexus was introduced 15 years ago, nobody ever did anything to upgrade the functionality a bit, only AspectJ versions were bumped before.

Furthermore, only `*.java` files were being considered for compilation, no `*.aj` files. This was also fixed, but at the cost of duplication with regard to redefining two static methods `getSourceFiles` and `getSourceFilesForSourceRoot`. Other compiler components did it similarly, so the necessary refactoring to make the methods non-static and break them down into smaller parts in order to be able to override only the parts of them dealing with source file extensions, is a TODO which involves refactoring the other compiler components, too. I did not do that in this first step.

Another TODO: In contrast to the ECJ adapter, which uses the batch compiler, AJC (an ECJ fork!) is used via the internal AJDT interface, which is designed to be used by the Eclipse IDE. It would have been easier to actually also use the batch compiler right from the start, because then we can more easily map command line parameters and keep the adapter layer thin. Why the original author did that in 2005, remains a mystery.

The new AspectJ integration test uses a mixture of
  - native and @<!-- -->AspectJ syntax variants,
  - `*.java` and `*.aj` aspect source files,
  - production (`src/main`) and test (`src/test`) aspects.

This is all covered by a single IT. In the end, the test asserts on the complete JUnit console log, which has to look a certain way in order to reflect that
  - compilation and test were successful,
  - all 3 aspects did what they are supposed to do.
