### PR TITLE
eclipse compiler: set generated source dir even if no annotation processor is configured

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -164,6 +164,17 @@ public class EclipseJavaCompiler
         List<String> extraSourceDirs = new ArrayList<>();
         if ( !isPreJava1_6( config ) )
         {
+            File generatedSourcesDir = config.getGeneratedSourcesDirectory();
+            if ( generatedSourcesDir != null )
+            {
+                generatedSourcesDir.mkdirs();
+                extraSourceDirs.add( generatedSourcesDir.getAbsolutePath() );
+
+                //-- option to specify where annotation processor is to generate its output
+                args.add( "-s" );
+                args.add( generatedSourcesDir.getAbsolutePath() );
+            }
+
             //now add jdk 1.6 annotation processing related parameters
             String[] annotationProcessors = config.getAnnotationProcessors();
             List<String> processorPathEntries = config.getProcessorPathEntries();
@@ -191,16 +202,6 @@ public class EclipseJavaCompiler
                     args.add( getPathString( processorPathEntries ) );
                 }
 
-                File generatedSourcesDir = config.getGeneratedSourcesDirectory();
-                if ( generatedSourcesDir != null )
-                {
-                    generatedSourcesDir.mkdirs();
-                    extraSourceDirs.add( generatedSourcesDir.getAbsolutePath() );
-
-                    //-- option to specify where annotation processor is to generate its output
-                    args.add( "-s" );
-                    args.add( generatedSourcesDir.getAbsolutePath() );
-                }
                 if ( config.getProc() != null )
                 {
                     args.add( "-proc:" + config.getProc() );


### PR DESCRIPTION
Synchronized with the javac compiler: https://github.com/codehaus-plexus/plexus-compiler/blob/master/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java#L269

For a multimodule maven project using the eclipse compiler, generated source files are currently created in the project root directory instead of the `target/generated-(test-)sources` of the submodule.