### PR TITLE
Issue #166: Fix maven dependencies

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -16,6 +16,10 @@
   <dependencies>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-compiler-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
plexus-compiler-eclipse 2.9.0 depends on plexus-compiler-api 2.9.0
or newer since it makes use of CompilerConfiguration.getWarnings().

Declare the dependency to match the API the plug-in is actually built
against, ensuring that maven-compiler-plugin will also pull in the
correct API version when people use plexus-compiler-eclipse.