### PR TITLE
javac dump debug file should not be written in classes directory as it will be included in jar. change directory and make name configurable

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -172,6 +172,12 @@ public class CompilerConfiguration
      */
     private boolean forceJavacCompilerUse=false;
 
+    /**
+     * force a different of the debug file containing the forked command run (such javac.sh)
+     * @since 2.9.1
+     */
+    private String debugFileName;
+
     // ----------------------------------------------------------------------
     //
     // ----------------------------------------------------------------------
@@ -718,6 +724,16 @@ public class CompilerConfiguration
     public void setCompilerReuseStrategy( CompilerReuseStrategy compilerReuseStrategy )
     {
         this.compilerReuseStrategy = compilerReuseStrategy;
+    }
+
+    public String getDebugFileName()
+    {
+        return debugFileName;
+    }
+
+    public void setDebugFileName(String debugFileName)
+    {
+        this.debugFileName = debugFileName;
     }
 
     /**

--- a/plexus-compilers/plexus-compiler-j2objc/README.md
+++ b/plexus-compilers/plexus-compiler-j2objc/README.md
@@ -23,7 +23,7 @@ J2ObjC Plexus compiler
               <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-compiler-j2objc</artifactId>
-                <version>2.8.1-SNAPSHOT</version>
+                <version>2.9.1-SNAPSHOT</version>
               </dependency>          
             </dependencies>
           </plugin>

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -559,7 +559,7 @@ public class JavacCompiler
 
         try
         {
-            File argumentsFile = createFileWithArguments( args, config.getOutputLocation() );
+            File argumentsFile = createFileWithArguments( args, config.getBuildDirectory().getAbsolutePath() );
             cli.addArguments(
                 new String[]{ "@" + argumentsFile.getCanonicalPath().replace( File.separatorChar, '/' ) } );
 
@@ -594,8 +594,10 @@ public class JavacCompiler
 
         if ( ( getLogger() != null ) && getLogger().isDebugEnabled() )
         {
+            String debugFileName = StringUtils.isEmpty(config.getDebugFileName()) ? "javac" : config.getDebugFileName();
+
             File commandLineFile =
-                new File( config.getOutputLocation(), "javac." + ( Os.isFamily( Os.FAMILY_WINDOWS ) ? "bat" : "sh" ) );
+                new File( config.getBuildDirectory(),  StringUtils.trim(debugFileName) + "." + ( Os.isFamily( Os.FAMILY_WINDOWS ) ? "bat" : "sh" ) );
             try
             {
                 FileUtils.fileWrite( commandLineFile.getAbsolutePath(), cli.toString().replaceAll( "'", "" ) );


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

Fixes https://github.com/codehaus-plexus/plexus-compiler/issues/165
