### PR TITLE
make java 11 as project base but keep javac release 8, we will be able to upgrade ecj and errorprone

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,6 +29,7 @@ jobs:
     name: Build it
     uses: codehaus-plexus/.github/.github/workflows/maven.yml@v0.0.1
     with:
+      jdk-fast-fail-build: '11'
       jdk-matrix: '["11", "17"]'
       jdk-distribution-matrix: '["zulu", "temurin"]'
       os-matrix: '["ubuntu-latest","windows-latest", "macOS-latest"]'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build it
     uses: codehaus-plexus/.github/.github/workflows/maven.yml@v0.0.1
     with:
-      jdk-matrix: '["8", "11", "17"]'
+      jdk-matrix: '["11", "17"]'
       jdk-distribution-matrix: '["zulu", "temurin"]'
       os-matrix: '["ubuntu-latest","windows-latest", "macOS-latest"]'
       maven_args: 'verify javadoc:javadoc -e -B -V -fae -Pno-tests-if-not-on-osx'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       jdk-fast-fail-build: '11'
       jdk-matrix: '["11", "17"]'
-      jdk-distribution-matrix: '["zulu", "temurin"]'
+      jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica"]'
       os-matrix: '["ubuntu-latest","windows-latest", "macOS-latest"]'
       maven_args: 'verify javadoc:javadoc -e -B -V -fae -Pno-tests-if-not-on-osx'
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
 
   build:
     name: Build it
-    uses: codehaus-plexus/.github/.github/workflows/maven.yml@v0.0.1
+    uses: codehaus-plexus/.github/.github/workflows/maven.yml@master
     with:
       jdk-fast-fail-build: '11'
       jdk-matrix: '["11", "17"]'

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
               <rules>
                 <requireJavaVersion>
                   <version>[11,)</version>
-                  <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 8 or newer</message>
+                  <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 11 or newer</message>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <scm.url>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</scm.url>
-    <javaVersion>8</javaVersion>
+    <javaVersion>11</javaVersion>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2021-10-18T08:22:06Z</project.build.outputTimestamp>
     <jupiter.version>5.8.2</jupiter.version>
@@ -123,6 +123,13 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <release>8</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
             <releaseProfiles>plexus-release,tools.jar</releaseProfiles>
@@ -192,7 +199,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8,)</version>
+                  <version>[11,)</version>
                   <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 8 or newer</message>
                 </requireJavaVersion>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <connection>${scm.url}</connection>
     <developerConnection>${scm.url}</developerConnection>
     <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
-    <tag>master</tag>
   </scm>
   <issueManagement>
     <system>github</system>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
