### PR TITLE
[eclipse-compiler] Resort sources to have module-info.java first

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -37,6 +37,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -262,6 +262,8 @@ public class EclipseJavaCompiler
             return new CompilerResult( true, messageList );
         }
 
+        allSources = resortSourcesToPutModuleInfoFirst( allSources );
+
         // Compile
         try
         {
@@ -474,6 +476,29 @@ public class EclipseJavaCompiler
         {
             throw new RuntimeException( x ); // sigh
         }
+    }
+
+    static List<String> resortSourcesToPutModuleInfoFirst( List<String> allSources )
+    {
+        ArrayList<String> resorted = new ArrayList<>();
+
+        for ( String mi : allSources )
+        {
+            if ( mi.endsWith( "module-info.java" ) )
+            {
+                resorted.add( mi );
+            }
+        }
+
+        for ( String nmi : allSources )
+        {
+            if ( !nmi.endsWith( "module-info.java") )
+            {
+                resorted.add( nmi );
+            }
+        }
+
+        return resorted;
     }
 
     static boolean processCustomArguments( CompilerConfiguration config, List<String> args )

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
@@ -1,0 +1,60 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EclipseJavaCompilerTest
+{
+    @ParameterizedTest
+    @MethodSource( "sources" )
+    void testReorderedSources( List<String> expected, List<String> inputSources )
+    {
+        List<String> resorted = EclipseJavaCompiler.resortSourcesToPutModuleInfoFirst( inputSources );
+
+        assertEquals( expected, resorted );
+    }
+
+    static Stream<Arguments> sources()
+    {
+        List<String> expectedOrder = asList(
+                "module-info.java",
+                "plexus/A.java",
+                "plexus/B.java",
+                "eclipse/A.java"
+        );
+
+        List<String> moduleInfoAlreadyFirst = asList(
+                "module-info.java",
+                "plexus/A.java",
+                "plexus/B.java",
+                "eclipse/A.java"
+        );
+
+        List<String> moduleInfoSomewhereInTheMiddle = asList(
+                "plexus/A.java",
+                "module-info.java",
+                "plexus/B.java",
+                "eclipse/A.java"
+        );
+
+        List<String> moduleInfoAsLast = asList(
+                "plexus/A.java",
+                "plexus/B.java",
+                "eclipse/A.java",
+                "module-info.java"
+        );
+
+        return Stream.of(
+                Arguments.arguments( expectedOrder, moduleInfoAlreadyFirst ),
+                Arguments.arguments( expectedOrder, moduleInfoSomewhereInTheMiddle ),
+                Arguments.arguments( expectedOrder, moduleInfoAsLast )
+        );
+    }
+}


### PR DESCRIPTION
[Batch compiler: unexpected errors if module-info.java doesn't come first](https://bugs.eclipse.org/bugs/show_bug.cgi?id=569833)