### PR TITLE
Avoid NPE in AspectJCompilerTest on AspectJ 1.9.8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2022-04-30T04:30:22Z</project.build.outputTimestamp>
     <jupiter.version>5.8.2</jupiter.version>
-    <aspectj.version>1.9.7</aspectj.version>
+    <aspectj.version>1.9.9.1</aspectj.version>
     <maven.version>3.2.5</maven.version>
     <errorprone.version>2.14.0</errorprone.version>
     <trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
Due to changed Eclipse Compiler (JDT Core) upstream of AJC, we need to call `buildArgParser.populateBuildConfig(..)` in order to avoid an NPE when `AjBuildConfig.getCheckedClasspaths()` is called later during compilation.

Only the unit test (which is not really a unit test) is affected by this problem, because it compiles in-process. The `aspectj-compiler` IT was still passing before this change.

Closes https://github.com/eclipse/org.aspectj/issues/169.