### PR TITLE
Avoid NPE in AspectJCompilerTest on AspectJ 1.9.8+

### DIFF
--- a/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
@@ -340,7 +340,10 @@ public class AspectJCompiler
     private AjBuildConfig buildCompilerConfig( CompilerConfiguration config )
         throws CompilerException
     {
-        AjBuildConfig buildConfig = new AjBuildConfig(new BuildArgParser(new AspectJMessagePrinter(config.isVerbose())));
+        BuildArgParser buildArgParser = new BuildArgParser(new AspectJMessagePrinter(config.isVerbose()));
+        AjBuildConfig buildConfig = new AjBuildConfig(buildArgParser);
+        // Avoid NPE when AjBuildConfig.getCheckedClasspaths() is called later during compilation
+        buildArgParser.populateBuildConfig(buildConfig, new String[0], true, null);
         buildConfig.setIncrementalMode( false );
 
         String[] files = getSourceFiles( config );

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2022-04-30T04:30:22Z</project.build.outputTimestamp>
     <jupiter.version>5.8.2</jupiter.version>
-    <aspectj.version>1.9.7</aspectj.version>
+    <aspectj.version>1.9.9.1</aspectj.version>
     <maven.version>3.2.5</maven.version>
     <errorprone.version>2.14.0</errorprone.version>
     <trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
Due to changed Eclipse Compiler (JDT Core) upstream of AJC, we need to call `buildArgParser.populateBuildConfig(..)` in order to avoid an NPE when `AjBuildConfig.getCheckedClasspaths()` is called later during compilation.

Only the unit test (which is not really a unit test) is affected by this problem, because it compiles in-process. The `aspectj-compiler` IT was still passing before this change.

Supersedes #227. Somehow, PRs on top of other PRs are not working as expected.

Closes https://github.com/eclipse/org.aspectj/issues/169.