### PR TITLE
Ensure that EclipseJavaCompiler doesn't pass duplicate source files to ECJ

### DIFF
--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -37,7 +37,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map.Entry;
@@ -245,7 +247,7 @@ public class EclipseJavaCompiler
         }
 
         // Collect sources
-        List<String> allSources = new ArrayList<>();
+        Set<String> allSources = new HashSet<>();
         for ( String source : config.getSourceLocations() )
         {
             File srcFile = new File( source );
@@ -502,9 +504,9 @@ public class EclipseJavaCompiler
         return false;
     }
 
-    static List<String> resortSourcesToPutModuleInfoFirst( List<String> allSources )
+    static Set<String> resortSourcesToPutModuleInfoFirst( Set<String> allSources )
     {
-        ArrayList<String> resorted = new ArrayList<>();
+        Set<String> resorted = new LinkedHashSet<>( allSources.size() );
 
         for ( String mi : allSources )
         {
@@ -652,7 +654,7 @@ public class EclipseJavaCompiler
         return null;
     }
 
-    private void addExtraSources( File dir, List<String> allSources )
+    private void addExtraSources( File dir, Set<String> allSources )
     {
         DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir( dir.getAbsolutePath() );

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -14,42 +15,42 @@ class EclipseJavaCompilerTest
 {
     @ParameterizedTest
     @MethodSource( "sources" )
-    void testReorderedSources( List<String> expected, List<String> inputSources )
+    void testReorderedSources( Set<String> expected, Set<String> inputSources )
     {
-        List<String> resorted = EclipseJavaCompiler.resortSourcesToPutModuleInfoFirst( inputSources );
+        Set<String> resorted = EclipseJavaCompiler.resortSourcesToPutModuleInfoFirst( inputSources );
 
         assertEquals( expected, resorted );
     }
 
     static Stream<Arguments> sources()
     {
-        List<String> expectedOrder = asList(
+        Set<String> expectedOrder = new LinkedHashSet<>( asList(
                 "module-info.java",
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        );
+        ) );
 
-        List<String> moduleInfoAlreadyFirst = asList(
+        Set<String> moduleInfoAlreadyFirst = new LinkedHashSet<>( asList(
                 "module-info.java",
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        );
+        ) );
 
-        List<String> moduleInfoSomewhereInTheMiddle = asList(
+        Set<String> moduleInfoSomewhereInTheMiddle = new LinkedHashSet<>( asList(
                 "plexus/A.java",
                 "module-info.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        );
+        ) );
 
-        List<String> moduleInfoAsLast = asList(
+        Set<String> moduleInfoAsLast = new LinkedHashSet<>( asList(
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java",
                 "module-info.java"
-        );
+        ) );
 
         return Stream.of(
                 Arguments.arguments( expectedOrder, moduleInfoAlreadyFirst ),


### PR DESCRIPTION
Fixes #229

I tried setting excludes for `DirectoryScanner`, but `allSources` contains absolute paths at that point, making it unecessarily complicated.
Also, checking whether `allSources` already contains a file would require frequent iterations of that list (or another helper `Set`).