### PR TITLE
Respect CompilerConfiguration.sourceFiles in EclipseJavaCompiler

### DIFF
--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/invoker.properties
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/invoker.properties
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 1.8+
+
+# without-dummy profile is used to have compiler plugin do actual compilation in the second run
+invoker.name.1 = Initial build
+invoker.goals.1 = clean compile -Pwithout-dummy
+invoker.buildResult.1 = success
+ 
+invoker.name.2 = Subsequent build without clean
+invoker.goals.2 = compile
+invoker.buildResult.2 = success

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/pom.xml
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.plexus.compiler.it</groupId>
+  <artifactId>simple-javac</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test for default configuration</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>${org.mapstruct.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <compilerId>eclipse</compilerId>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-api</artifactId>
+            <version>@pom.version@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-eclipse</artifactId>
+            <version>@pom.version@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${org.mapstruct.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>without-dummy</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/Dummy.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/Car.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/Car.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Car
+{
+    public String make;
+    public int numberOfSeats;
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/CarDto.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/CarDto.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class CarDto
+{
+    public String make;
+    public int seatCount;
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/CarMapper.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/CarMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CarMapper
+{
+
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+
+    @Mapping( source = "numberOfSeats", target = "seatCount" )
+    CarDto carToCarDto( Car car );
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/Dummy.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/src/main/java/Dummy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Dummy
+{
+
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/verify.groovy
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def mapperImplClass = new File( basedir, "target/classes/CarMapperImpl.class" )
+assert mapperImplClass.exists()
+
+def dummyClass = new File( basedir, "target/classes/Dummy.class" )
+assert dummyClass.exists()
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.count( "Changes detected - recompiling the module!" ) == 2

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerTest.java
@@ -4,8 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -15,42 +14,42 @@ class EclipseJavaCompilerTest
 {
     @ParameterizedTest
     @MethodSource( "sources" )
-    void testReorderedSources( Set<String> expected, Set<String> inputSources )
+    void testReorderedSources( List<String> expected, List<String> inputSources )
     {
-        Set<String> resorted = EclipseJavaCompiler.resortSourcesToPutModuleInfoFirst( inputSources );
+        List<String> resorted = EclipseJavaCompiler.resortSourcesToPutModuleInfoFirst( inputSources );
 
         assertEquals( expected, resorted );
     }
 
     static Stream<Arguments> sources()
     {
-        Set<String> expectedOrder = new LinkedHashSet<>( asList(
+        List<String> expectedOrder = asList(
                 "module-info.java",
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        ) );
+        );
 
-        Set<String> moduleInfoAlreadyFirst = new LinkedHashSet<>( asList(
+        List<String> moduleInfoAlreadyFirst = asList(
                 "module-info.java",
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        ) );
+        );
 
-        Set<String> moduleInfoSomewhereInTheMiddle = new LinkedHashSet<>( asList(
+        List<String> moduleInfoSomewhereInTheMiddle = asList(
                 "plexus/A.java",
                 "module-info.java",
                 "plexus/B.java",
                 "eclipse/A.java"
-        ) );
+        );
 
-        Set<String> moduleInfoAsLast = new LinkedHashSet<>( asList(
+        List<String> moduleInfoAsLast = asList(
                 "plexus/A.java",
                 "plexus/B.java",
                 "eclipse/A.java",
                 "module-info.java"
-        ) );
+        );
 
         return Stream.of(
                 Arguments.arguments( expectedOrder, moduleInfoAlreadyFirst ),


### PR DESCRIPTION
Just like JavacCompiler does, to avoid "FilerException: Source file already created" during annotation processing when running mvn without clean after changing code.

Fixes #232 

---

The crucial thing here is that the compiler will run the annotation processors anyway, so it makes no sense to explicitly specify sources generated from the previous run.

---

Without the change to `EclipseJavaCompiler` the new IT would fail with:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project simple-javac: Compilation failure
[ERROR] /home/famod/proj/plexus-compiler/plexus-compiler-its/target/it/eclipse-compiler-mapstruct/src/main/java/CarMapper.java:[25,18] Internal error in the mapping processor: java.lang.RuntimeException: javax.annotation.processing.FilerException: Source file already exists : CarMapperImpl   at org.mapstruct.ap.internal.processor.MapperRenderingProcessor.createSourceFile(MapperRenderingProcessor.java:59)      at org.mapstruct.ap.internal.processor.MapperRenderingProcessor.writeToSourceFile(MapperRenderingProcessor.java:39)     at org.mapstruct.ap.internal.processor.MapperRenderingProcessor.process(MapperRenderingProcessor.java:29)       at org.mapstruct.ap.internal.processor.MapperRenderingProcessor.process(MapperRenderingProcessor.java:24)       at org.mapstruct.ap.MappingProcessor.process(MappingProcessor.java:350)        at org.mapstruct.ap.MappingProcessor.processMapperTypeElement(MappingProcessor.java:330)         at org.mapstruct.ap.MappingProcessor.processMapperElements(MappingProcessor.java:279)   at org.mapstruct.ap.MappingProcessor.process(MappingProcessor.java:174)         at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:142)     at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:124)       at org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManager.java:172)    at org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:953)     at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:450)        at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:426)        at org.eclipse.jdt.internal.compiler.batch.Main.performCompilation(Main.java:4776)      at org.eclipse.jdt.internal.compiler.tool.EclipseCompilerImpl.call(EclipseCompilerImpl.java:100)        at org.eclipse.jdt.internal.compiler.tool.EclipseCompiler$1.call(EclipseCompiler.java:196)      at org.codehaus.plexus.compiler.eclipse.EclipseJavaCompiler.performCompile(EclipseJavaCompiler.java:374)        at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:1209)        at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:198)         at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)      at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)      at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)      at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)      at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)      at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)       at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)       at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)         at org.apache.maven.cli.MavenCli.execute(MavenCli.java:972)     at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293)      at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)       at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)     at java.base/java.lang.reflect.Method.invoke(Method.java:568)   at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)          at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)          at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)  Caused by: javax.annotation.processing.FilerException: Source file already exists : CarMapperImpl         at org.eclipse.jdt.internal.compiler.apt.dispatch.BatchFilerImpl.createSourceFile(BatchFilerImpl.java:149)      at org.mapstruct.ap.internal.processor.MapperRenderingProcessor.createSourceFile(MapperRenderingProcessor.java:56)      ... 41 more
```
(sorry for the garbled output but that's the way it's printed out by compiler-plugin)