### PR TITLE
simplify "Compiling" info message: display relative path

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
@@ -299,4 +299,16 @@ public abstract class AbstractCompiler
 
         return args;
     }
+
+    protected void logCompiling( String[] sourceFiles, CompilerConfiguration config )
+    {
+        if ( ( getLogger() != null ) && getLogger().isInfoEnabled() )
+        {
+            String to = ( config.getWorkingDirectory() == null ) ? config.getOutputLocation() :
+                config.getWorkingDirectory().toPath().relativize( new File( config.getOutputLocation() ).toPath() ).toString();
+            getLogger().info( "Compiling " +
+                                  ( sourceFiles == null ? "" : ( sourceFiles.length + " source file" + ( sourceFiles.length == 1 ? " " : "s " ) ) ) +
+                                  "to " + to );
+        }
+  }
 }

--- a/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
@@ -65,6 +65,23 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-api</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
@@ -320,9 +320,11 @@ public class AspectJCompiler
             return new CompilerResult();
         }
 
+        String to = ( config.getWorkingDirectory() == null ) ? config.getOutputLocation() :
+            config.getWorkingDirectory().toPath().relativize( destinationDir.toPath() ).toString();
         System.out.println(
             "Compiling " + sourceFiles.length + " " + "source file" + ( sourceFiles.length == 1 ? "" : "s" ) + " to "
-                + destinationDir.getAbsolutePath() );
+                + to );
 
         //        String[] args = buildCompilerArguments( config, sourceFiles );
         AjBuildConfig buildConfig = buildCompilerConfig( config );

--- a/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/main/java/org/codehaus/plexus/compiler/ajc/AspectJCompiler.java
@@ -320,11 +320,7 @@ public class AspectJCompiler
             return new CompilerResult();
         }
 
-        String to = ( config.getWorkingDirectory() == null ) ? config.getOutputLocation() :
-            config.getWorkingDirectory().toPath().relativize( destinationDir.toPath() ).toString();
-        System.out.println(
-            "Compiling " + sourceFiles.length + " " + "source file" + ( sourceFiles.length == 1 ? "" : "s" ) + " to "
-                + to );
+        logCompiling( sourceFiles, config );
 
         //        String[] args = buildCompilerArguments( config, sourceFiles );
         AjBuildConfig buildConfig = buildCompilerConfig( config );

--- a/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
+++ b/plexus-compilers/plexus-compiler-csharp/src/main/java/org/codehaus/plexus/compiler/csharp/CSharpCompiler.java
@@ -115,8 +115,7 @@ public class CSharpCompiler
             return new CompilerResult().success( true );
         }
 
-        System.out.println( "Compiling " + sourceFiles.length + " " + "source file" +
-                                ( sourceFiles.length == 1 ? "" : "s" ) + " to " + destinationDir.getAbsolutePath() );
+        logCompiling( sourceFiles, config );
 
         String[] args = buildCompilerArguments( config, sourceFiles );
 

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -251,6 +251,8 @@ public class EclipseJavaCompiler
 
         allSources = resortSourcesToPutModuleInfoFirst( allSources );
 
+        logCompiling( null, config );
+
         // Compile
         try
         {

--- a/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
+++ b/plexus-compilers/plexus-compiler-j2objc/src/main/java/org/codehaus/plexus/compiler/j2objc/J2ObjCCompiler.java
@@ -122,9 +122,7 @@ public class J2ObjCCompiler
             return new CompilerResult().success( true );
         }
 
-        System.out.println(
-            "Compiling " + sourceFiles.length + " " + "source file" + ( sourceFiles.length == 1 ? "" : "s" ) + " to "
-                + destinationDir.getAbsolutePath() );
+        logCompiling( sourceFiles, config );
 
         String[] args = buildCompilerArguments( config, sourceFiles );
 

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -141,14 +141,7 @@ public class JavacCompiler
             return new CompilerResult();
         }
 
-        if ( ( getLogger() != null ) && getLogger().isInfoEnabled() )
-        {
-            String to = ( config.getWorkingDirectory() == null ) ? config.getOutputLocation() :
-                config.getWorkingDirectory().toPath().relativize( destinationDir.toPath() ).toString();
-            getLogger().info( "Compiling " + sourceFiles.length + " " +
-                                  "source file" + ( sourceFiles.length == 1 ? "" : "s" ) +
-                                  " to " + to );
-        }
+        logCompiling( sourceFiles, config );
 
         String[] args = buildCompilerArguments( config, sourceFiles );
 

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -143,9 +143,11 @@ public class JavacCompiler
 
         if ( ( getLogger() != null ) && getLogger().isInfoEnabled() )
         {
+            String to = ( config.getWorkingDirectory() == null ) ? config.getOutputLocation() :
+                config.getWorkingDirectory().toPath().relativize( destinationDir.toPath() ).toString();
             getLogger().info( "Compiling " + sourceFiles.length + " " +
                                   "source file" + ( sourceFiles.length == 1 ? "" : "s" ) +
-                                  " to " + destinationDir.getAbsolutePath() );
+                                  " to " + to );
         }
 
         String[] args = buildCompilerArguments( config, sourceFiles );


### PR DESCRIPTION
simplify current info message

```
[INFO] Compiling 29 source files to /full/path/to/project/which/is/very/noisy/target/test-classes
```

by replacing full path with relative to basedir:

```
[INFO] Compiling 29 source files to target/test-classes
```
