### PR TITLE
Restore Java 8 runtime compatibility

### DIFF
--- a/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
@@ -107,9 +107,9 @@
       </build>
     </profile>
     <profile>
-      <id>jdk16</id>
+      <id>jdk11</id>
       <activation>
-        <jdk>[16,)</jdk>
+        <jdk>[11,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -25,7 +25,8 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>ecj</artifactId>
-      <version>3.32.0</version>
+      <!-- maximum version with bytecode 8 -->
+      <version>3.26.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -39,9 +39,9 @@
 
   <profiles>
     <profile>
-      <id>16+</id>
+      <id>11+</id>
       <activation>
-        <jdk>[16,)</jdk>
+        <jdk>[11,)</jdk>
       </activation>
       <build>
         <plugins>
@@ -49,13 +49,18 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <skip>true</skip>
-<!--              <argLine>-->
-<!--                &#45;&#45;add-modules java.se-->
-<!--                &#45;&#45;add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED-->
-<!--                &#45;&#45;add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED-->
-<!--                &#45;&#45;add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED-->
-<!--              </argLine>-->
+              <argLine>
+                --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+                --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+              </argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
@@ -9,10 +9,6 @@ public class JavacErrorProneCompilerTest
     extends AbstractCompilerTest
 {
 
-    protected boolean java8() {
-        return System.getProperty( "java.version" ).startsWith( "1.8" );
-    }
-
     @Override
     protected String getRoleHint()
     {
@@ -22,11 +18,13 @@ public class JavacErrorProneCompilerTest
     @Override
     protected int expectedWarnings()
     {
-        if ( java8() ) {
+        String javaVersion = getJavaVersion();
+        if (javaVersion.startsWith("1.8")) {
             return 1;
-        }
-        else
-        {
+        } else {
+            if (javaVersion.contains("18") || javaVersion.contains("19") || javaVersion.contains("20")) {
+                return 5;
+            }
             return 2;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,11 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2022-12-17T17:23:49Z</project.build.outputTimestamp>
     <jupiter.version>5.9.2</jupiter.version>
-    <aspectj.version>1.9.9.1</aspectj.version>
+    <!-- maximum version with bytecode 8 -->
+    <aspectj.version>1.9.7</aspectj.version>
     <maven.version>3.2.5</maven.version>
-    <errorprone.version>2.18.0</errorprone.version>
+    <!-- maximum version with bytecode 8 -->
+    <errorprone.version>2.8.1</errorprone.version>
     <trimStackTrace>false</trimStackTrace>
     <preparationGoals>clean install</preparationGoals>
     <maven.compiler.version>3.11.0</maven.compiler.version>
@@ -197,6 +199,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.3.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.6.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -210,6 +219,20 @@
                   <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 11 or newer</message>
                 </requireJavaVersion>
               </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
+              <fail>true</fail>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Java 11 is required at runtime for:
- aspectj 1.9.8+ https://github.com/eclipse/org.aspectj/blob/master/docs/dist/doc/README-199.html
- org.eclipse.jdt:ecj 3.27.0+
- com.google.errorprone:error_prone_core 2.9.0+