### PR TITLE
Parse and forward JavaC 'Note:' level messages

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -798,7 +798,7 @@ public class JavacCompiler
             }
             else if ( ( buffer.length() == 0 ) && isNote( line ) )
             {
-                // skip, JDK 1.5 telling us deprecated APIs are used but -Xlint:deprecation isn't set
+                errors.add( new CompilerMessage( line, CompilerMessage.Kind.NOTE ) );
             }
             else if ( ( buffer.length() == 0 ) && isMisc( line ) )
             {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -125,6 +125,16 @@ public class ErrorMessageParserTest
     }
 
     @Test
+    public void testNoteMessage() throws IOException
+    {
+        String error = "Note: My fancy annotation processor info" + EOL;
+        List<CompilerMessage> messages = JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(error)));
+        assertThat(messages.size(), is(1));
+        assertThat(messages.get(0).isError(), is(false));
+        assertThat(messages.get(0).getMessage(), is("My fancy annotation processor info"));
+    }
+
+    @Test
     public void testUnknownSymbolError()
     {
         String error = "./org/codehaus/foo/UnknownSymbol.java:7: cannot find symbol" + EOL +


### PR DESCRIPTION
Theses messages can be generated by annotation processors using `printMessage(Diagnostic.Kind.NOTE, "...")`.