### PR TITLE
Write raw javac output to a log file

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -56,8 +56,13 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -662,6 +667,14 @@ public class JavacCompiler extends AbstractCompiler {
             if (getLog().isDebugEnabled()) {
                 getLog().debug("Compiler output:{}{}", EOL, out.getOutput());
             }
+
+            Path logsDir = config.getBuildDirectory().toPath().resolve("compiler-logs");
+            if (!Files.exists(logsDir)) {
+                Files.createDirectories(logsDir);
+            }
+            SimpleDateFormat dateFormat = new SimpleDateFormat("'javac'_yyyy-MM-dd'T'HH_mm_ss.'log'");
+            String logFileName = dateFormat.format(new Date());
+            Files.write(logsDir.resolve(logFileName), out.getOutput().getBytes(StandardCharsets.UTF_8));
 
             messages = parseModernStream(returnCode, new BufferedReader(new StringReader(out.getOutput())));
         } catch (CommandLineException | IOException e) {


### PR DESCRIPTION
Sometimes it is useful to look at the raw javac output when running in fork mode.

With this PR, the raw javac logs will be written to `target/compiler-logs/javac_*.log`