### PR TITLE
JavacCompiler.java had a space in the wrong place

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -85,7 +85,7 @@ import org.codehaus.plexus.util.cli.Commandline;
  * @author Others
  *
  */
-@Component( role = Compiler.class, hint = "javac ")
+@Component( role = Compiler.class, hint = "javac" )
 public class JavacCompiler
     extends AbstractCompiler
 {


### PR DESCRIPTION
It looks like the style rule is that annotations are written `@Foo( param="spaces in between parens and params" )`, but here, it the space was _within_ the string literal. Which would break everything, except evidently elsewhere these compilerId strings are perhaps trimmed, or, if not, the META-INF serviceloader infra trims these. Still, it was weird, and ugly.