### PR TITLE
Parse and forward JavaC 'Note:' level messages

### DIFF
--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -128,6 +128,20 @@ public abstract class AbstractCompilerTest {
 
     protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {}
 
+    /**
+     * Called once per compile iteration to allow configuration customization for
+     * tests.
+     *
+     * @param compilerConfig
+     *            configuration used for this compile iteration.
+     * @param filename
+     *            file about to be compiled this iteration.
+     * @since 2.14.0
+     */
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig, String filename) {
+        configureCompilerConfig(compilerConfig);
+    }
+
     @Test
     public void testCompilingSources() throws Exception {
         List<CompilerMessage> messages = new ArrayList<>();
@@ -257,7 +271,7 @@ public abstract class AbstractCompilerTest {
 
             compilerConfig.setForceJavacCompilerUse(this.forceJavacCompilerUse);
 
-            configureCompilerConfig(compilerConfig);
+            configureCompilerConfig(compilerConfig, filename);
 
             String target = getTargetVersion();
             if (StringUtils.isNotEmpty(target)) {
@@ -319,6 +333,12 @@ public abstract class AbstractCompilerTest {
         return 0;
     }
 
+    /**
+     * Count of output generated at the {@link Kind#NOTE} level.
+     *
+     * @return count
+     * @since 2.14.0
+     */
     protected int expectedNotes() {
         return 0;
     }

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjLogParser.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjLogParser.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.util.List;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+
+/**
+ * Log parser interface.
+ *
+ * @author <a href="mailto:jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public interface EcjLogParser {
+
+    /**
+     * Pares an Eclipse Compiler log file.
+     *
+     * @param logFile          file to parse.
+     * @param errorsAsWarnings if errors should be down-graded to warnings.
+     * @return the messages.
+     * @throws Exception on parse errors.
+     */
+    List<CompilerMessage> parse(File logFile, boolean errorsAsWarnings) throws Exception;
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjResponseParser.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjResponseParser.java
@@ -18,9 +18,10 @@ import org.codehaus.plexus.compiler.CompilerMessage.Kind;
 
 /**
  * @author <a href="mailto:jal@etc.to">Frits Jalvingh</a>
+ * @author <a href="mailto:jfaust@tsunamit.com">Jason Faust</a>
  * Created on 31-3-18.
  */
-public class EcjResponseParser {
+public class EcjResponseParser implements EcjLogParser {
     /*--------------------------------------------------------------*/
     /*	CODING:	Decode ECJ -log format results.						*/
     /*--------------------------------------------------------------*/
@@ -40,6 +41,7 @@ public class EcjResponseParser {
      * @param errorsAsWarnings should we treat errors as warnings
      *                         Scan the specified response file for compilation messages.
      */
+    @Override
     public List<CompilerMessage> parse(File xmltf, boolean errorsAsWarnings) throws Exception {
         // if(xmltf.length() < 80)
         //	return;
@@ -106,20 +108,33 @@ public class EcjResponseParser {
             throws Exception {
         String id = xsr.getAttributeValue(null, "optionKey"); // Key for the problem
         int startline = getInt(xsr, "line");
-        int column = getInt(xsr, "charStart");
-        int endCol = getInt(xsr, "charEnd");
+        int column = 0;
+        int endCol = 0;
         String sev = xsr.getAttributeValue(null, "severity");
         String message = "Unknown message?";
 
-        // -- Go watch for "message"
+        // -- Go watch for "message" and "source_context"
         while (xsr.hasNext()) {
             int type = xsr.nextTag();
             if (type == XMLStreamConstants.START_ELEMENT) {
                 if ("message".equals(xsr.getLocalName())) {
                     message = xsr.getAttributeValue(null, "value");
                 }
+                if ("source_context".equals(xsr.getLocalName())) {
+                    column = getInt(xsr, "sourceStart");
+                    if (column != -1) {
+                        column += 1; // Offset to 1-based index
+                    } else {
+                        column = 0;
+                    }
+                    endCol = getInt(xsr, "sourceEnd");
+                    if (endCol != -1) {
+                        endCol += 1; // Offset to 1-based index
+                    } else {
+                        endCol = 0;
+                    }
+                }
                 ignoreTillEnd(xsr);
-
             } else if (type == XMLStreamConstants.END_ELEMENT) {
                 break;
             }

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjTextLogParser.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EcjTextLogParser.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerMessage.Kind;
+
+/**
+ * Parser for non-XML Eclipse Compiler output.
+ *
+ * @author <a href="mailto:jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public class EcjTextLogParser implements EcjLogParser {
+
+    private static final String TEN_DASH = "----------";
+    private static final String PATTERN_LEVEL_FILE = "^\\d+\\.\\s+(\\w+)\\s+in\\s+(.*)\\s+\\(at line (\\d+)\\)$";
+
+    private Pattern levelFile = Pattern.compile(PATTERN_LEVEL_FILE);
+
+    @Override
+    public List<CompilerMessage> parse(File logFile, boolean errorsAsWarnings) throws Exception {
+        List<CompilerMessage> ret = new ArrayList<>();
+        try (BufferedReader in =
+                new BufferedReader(new InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+            String line;
+            List<String> buffer = new LinkedList<>();
+            boolean header = true;
+
+            while ((line = in.readLine()) != null) {
+                if (header) {
+                    if (!line.startsWith(TEN_DASH)) {
+                        continue;
+                    }
+                    header = false;
+                }
+                if (line.startsWith(TEN_DASH)) {
+                    if (!buffer.isEmpty()) {
+                        ret.add(parse(buffer, errorsAsWarnings));
+                    }
+                    buffer.clear();
+                } else {
+                    buffer.add(line);
+                }
+            }
+        }
+        return ret;
+    }
+
+    private CompilerMessage parse(List<String> buffer, boolean errorsAsWarnings) {
+
+        Kind kind = null;
+        String file = null;
+        int lineNum = 0;
+        int startCol = 0;
+        int endCol = 0;
+        String message = null;
+
+        // First line, kind, file, lineNum
+        if (buffer.size() > 1) {
+            String str = buffer.get(0);
+            Matcher matcher = levelFile.matcher(str);
+            if (matcher.find()) {
+                file = matcher.group(2);
+                kind = decodeKind(matcher.group(1), errorsAsWarnings);
+                lineNum = Integer.parseInt(matcher.group(3));
+            }
+        }
+
+        // Last line, message
+        if (buffer.size() >= 2) {
+            String str = buffer.get(buffer.size() - 1);
+            message = str.trim();
+        }
+
+        // 2nd to last line, columns
+        if (buffer.size() >= 3) {
+            String str = buffer.get(buffer.size() - 2);
+            startCol = str.indexOf('^');
+            endCol = str.lastIndexOf('^');
+        }
+
+        return new CompilerMessage(file, kind, lineNum, startCol, lineNum, endCol, message);
+    }
+
+    private Kind decodeKind(String str, boolean errorsAsWarnings) {
+        if (str.equals("ERROR")) {
+            return errorsAsWarnings ? Kind.WARNING : Kind.ERROR;
+        }
+        if (str.equals("INFO")) {
+            return Kind.NOTE;
+        }
+        return Kind.WARNING;
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -1,5 +1,3 @@
-package org.codehaus.plexus.compiler.eclipse;
-
 /**
  * The MIT License
  * <p>
@@ -23,6 +21,8 @@ package org.codehaus.plexus.compiler.eclipse;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.codehaus.plexus.compiler.eclipse;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.tools.Diagnostic;
@@ -32,6 +32,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
@@ -42,6 +43,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
 
@@ -198,6 +200,28 @@ public class EclipseJavaCompiler extends AbstractCompiler {
             }
         }
 
+        // Check for custom -log
+        boolean tempLog;
+        File logFile;
+        EcjLogParser logParser;
+        Map<String, String> extras = config.getCustomCompilerArgumentsAsMap();
+        if (extras.containsKey("-log")) {
+            String key = extras.get("-log");
+            logFile = new File(key);
+            tempLog = false;
+            logParser = key.endsWith(".xml") ? new EcjResponseParser() : new EcjTextLogParser();
+        } else {
+            try {
+                logFile = File.createTempFile("ecjerr-", ".xml");
+            } catch (IOException e) {
+                throw new CompilerException("Unable to create temporary file for compiler output", e);
+            }
+            args.add("-log");
+            args.add(logFile.toString());
+            tempLog = true;
+            logParser = new EcjResponseParser();
+        }
+
         // -- classpath
         List<String> classpathEntries = new ArrayList<>(config.getClasspathEntries());
         classpathEntries.add(config.getOutputLocation());
@@ -343,14 +367,14 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                             });
                     log.debug(sw.toString());
 
-                    if (errorF.length() < 80) {
+                    if (logFile.length() < 80) {
                         throw new EcjFailureException(sw.toString());
                     }
-                    messageList = new EcjResponseParser().parse(errorF, errorsAsWarnings);
+                    messageList = logParser.parse(errorF, errorsAsWarnings);
                 } finally {
-                    if (null != errorF) {
+                    if (tempLog) {
                         try {
-                            errorF.delete();
+                            logFile.delete();
                         } catch (Exception x) {
                         }
                     }
@@ -358,14 +382,16 @@ public class EclipseJavaCompiler extends AbstractCompiler {
             }
             boolean hasError = false;
             for (CompilerMessage compilerMessage : messageList) {
-                if (compilerMessage.isError()) {
+                if (compilerMessage.isError()
+                        || (compilerMessage.getKind() == CompilerMessage.Kind.WARNING
+                                        || compilerMessage.getKind() == CompilerMessage.Kind.MANDATORY_WARNING)
+                                && config.isFailOnWarning()) {
                     hasError = true;
                     break;
                 }
             }
             if (!hasError && !success && !errorsAsWarnings) {
-                CompilerMessage.Kind kind =
-                        errorsAsWarnings ? CompilerMessage.Kind.WARNING : CompilerMessage.Kind.ERROR;
+                CompilerMessage.Kind kind = CompilerMessage.Kind.ERROR;
 
                 // -- Compiler reported failure but we do not seem to have one -> probable
                 // exception
@@ -437,7 +463,7 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                 if (null != optionValue) {
                     File propFile = new File(optionValue);
                     if (!propFile.exists() || !propFile.isFile()) {
-                        throw new IllegalArgumentException(
+                        throw new EcjFailureException(
                                 "Properties file specified by -properties " + propFile + " does not exist");
                     }
                 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Info.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/Info.java
@@ -1,0 +1,7 @@
+package org.codehaus.foo;
+
+public class Info {
+    {
+        "".equals(Integer.valueOf(1));
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/AbstractEclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/AbstractEclipseCompilerTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.codehaus.plexus.compiler.AbstractCompilerTest;
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
+
+/**
+ * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ */
+public abstract class AbstractEclipseCompilerTest extends AbstractCompilerTest {
+
+    private int expectedErrors;
+    private int expectedWarnings;
+    private int expectedNotes;
+    private Collection<String> expectedOutputFiles;
+
+    protected AbstractEclipseCompilerTest() {
+        this(5, 1, 1);
+    }
+
+    protected AbstractEclipseCompilerTest(int expectedErrors, int expectedWarnings, int expectedNotes) {
+        this(
+                expectedErrors,
+                expectedWarnings,
+                expectedNotes,
+                Arrays.asList(
+                        "org/codehaus/foo/Deprecation.class",
+                        "org/codehaus/foo/ExternalDeps.class",
+                        "org/codehaus/foo/Info.class",
+                        "org/codehaus/foo/Person.class"));
+    }
+
+    protected AbstractEclipseCompilerTest(
+            int expectedErrors, int expectedWarnings, int expectedNotes, Collection<String> expectedOutputFiles) {
+        this.expectedErrors = expectedErrors;
+        this.expectedWarnings = expectedWarnings;
+        this.expectedNotes = expectedNotes;
+        this.expectedOutputFiles = expectedOutputFiles;
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        File compileDir = new File(getBasedir() + "/target/" + getRoleHint());
+        if (!compileDir.exists() && !compileDir.mkdir()) {
+            throw new IOException("Unable to create compile target directory " + compileDir);
+        }
+
+        setCompilerDebug(true);
+        setCompilerDeprecationWarnings(true);
+    }
+
+    @Override
+    protected String getRoleHint() {
+        return "eclipse";
+    }
+
+    @Override
+    protected int expectedErrors() {
+        return expectedErrors;
+    }
+
+    @Override
+    protected int expectedWarnings() {
+        return expectedWarnings;
+    }
+
+    @Override
+    protected int expectedNotes() {
+        return expectedNotes;
+    }
+
+    protected Collection<String> expectedOutputFiles() {
+        return expectedOutputFiles;
+    }
+
+    @Override
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
+        compilerConfig.setSourceVersion("1.8");
+        compilerConfig.setTargetVersion("1.8");
+        //        compilerConfig.setReleaseVersion("1.8");
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EcjResponseParserTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EcjResponseParserTest.java
@@ -1,0 +1,173 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.util.List;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerMessage.Kind;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link EcjResponseParser}. Tests are written against ecj 3.15.0
+ * output.
+ *
+ * @author <a href="mailto:jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+@PlexusTest
+public class EcjResponseParserTest {
+
+    private static final String LOG_FILE_1 = "src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.xml";
+    private static final String LOG_FILE_2 = "src/test/resources/org/codehaus/plexus/compiler/eclipse/log-xml-0.xml";
+    private static final String LOG_FILE_3 =
+            "src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.xml";
+    private static final String LOG_FILE_4 =
+            "src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.xml";
+
+    /**
+     * Test for example compiler output in XML format.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParse() throws Exception {
+        File logFile = getTestFile(LOG_FILE_1);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjResponseParser parser = new EcjResponseParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(9, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(2), "Deprecation.java", Kind.WARNING, 7, 5, 30);
+        checkCompilerMessage(cm.get(3), "ExternalDeps.java", Kind.ERROR, 4, 8, 17);
+        checkCompilerMessage(cm.get(4), "ExternalDeps.java", Kind.ERROR, 12, 21, 31);
+        checkCompilerMessage(cm.get(5), "Info.java", Kind.NOTE, 5, 11, 11);
+        checkCompilerMessage(cm.get(6), "ReservedWord.java", Kind.ERROR, 5, 8, 13);
+        checkCompilerMessage(cm.get(7), "UnknownSymbol.java", Kind.ERROR, 7, 1, 3);
+        checkCompilerMessage(cm.get(8), "WrongClassname.java", Kind.ERROR, 3, 14, 27);
+    }
+
+    /**
+     * Test for example compiler output in XML format with errors reported as
+     * warnings.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParseErrorsAsWarnings() throws Exception {
+        File logFile = getTestFile(LOG_FILE_1);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjResponseParser parser = new EcjResponseParser();
+        List<CompilerMessage> cm = parser.parse(logFile, true);
+
+        assertEquals(9, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.WARNING, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.WARNING, 6, 1, 5);
+        checkCompilerMessage(cm.get(2), "Deprecation.java", Kind.WARNING, 7, 5, 30);
+        checkCompilerMessage(cm.get(3), "ExternalDeps.java", Kind.WARNING, 4, 8, 17);
+        checkCompilerMessage(cm.get(4), "ExternalDeps.java", Kind.WARNING, 12, 21, 31);
+        checkCompilerMessage(cm.get(5), "Info.java", Kind.NOTE, 5, 11, 11);
+        checkCompilerMessage(cm.get(6), "ReservedWord.java", Kind.WARNING, 5, 8, 13);
+        checkCompilerMessage(cm.get(7), "UnknownSymbol.java", Kind.WARNING, 7, 1, 3);
+        checkCompilerMessage(cm.get(8), "WrongClassname.java", Kind.WARNING, 3, 14, 27);
+    }
+
+    /**
+     * Test for ignoring top level errors.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testHeaderErrors() throws Exception {
+        File logFile = getTestFile(LOG_FILE_2);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjResponseParser parser = new EcjResponseParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(2, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.ERROR, 6, 1, 5);
+    }
+
+    /**
+     * Tests for parsing the contents of {@value #LOG_FILE_3}.
+     *
+     * @throws Exception on test failure.
+     */
+    public void testParse2() throws Exception {
+        File logFile = getTestFile(LOG_FILE_3);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjResponseParser parser = new EcjResponseParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(6, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "ECE.java", Kind.ERROR, 8, 13, 16);
+        checkCompilerMessage(cm.get(1), "ECE.java", Kind.ERROR, 16, 8, 40);
+        checkCompilerMessage(cm.get(2), "ECE.java", Kind.WARNING, 22, 9, 9);
+        checkCompilerMessage(cm.get(3), "ECE.java", Kind.WARNING, 27, 8, 40);
+        checkCompilerMessage(cm.get(4), "ECE.java", Kind.NOTE, 33, 13, 18);
+        checkCompilerMessage(cm.get(5), "ECE.java", Kind.NOTE, 35, 1, 95);
+    }
+
+    /**
+     * Tests for parsing the contents of {@value #LOG_FILE_4}.
+     *
+     * @throws Exception on test failure.
+     */
+    public void testParse4() throws Exception {
+        File logFile = getTestFile(LOG_FILE_4);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjResponseParser parser = new EcjResponseParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(1, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Column.java", Kind.ERROR, 2, 1, 5);
+    }
+
+    private void checkCompilerMessage(CompilerMessage cm, String file, Kind kind, int line, int startCol, int endCol) {
+        assertTrue(cm.getFile().endsWith(file), "Failure checking output for " + file);
+        assertEquals(kind, cm.getKind(), "Failure checking output for " + file);
+        assertEquals(line, cm.getStartLine(), "Failure checking output for " + file);
+        assertEquals(startCol, cm.getStartColumn(), "Failure checking output for " + file);
+        assertEquals(endCol, cm.getEndColumn(), "Failure checking output for " + file);
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EcjTextLogParserTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EcjTextLogParserTest.java
@@ -1,0 +1,175 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.util.List;
+
+import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.CompilerMessage.Kind;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link EcjTextLogParser}. Tests are written against ecj 3.15.0
+ * output.
+ *
+ * @author <a href="mailto:jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+@PlexusTest
+public class EcjTextLogParserTest {
+
+    private static final String LOG_FILE_1 = "src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.txt";
+    private static final String LOG_FILE_2 = "src/test/resources/org/codehaus/plexus/compiler/eclipse/log-text-0.log";
+    private static final String LOG_FILE_3 =
+            "src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.txt";
+    private static final String LOG_FILE_4 =
+            "src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.txt";
+
+    /**
+     * Test for example compiler output in non-XML format.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParse() throws Exception {
+        File logFile = getTestFile(LOG_FILE_1);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjTextLogParser parser = new EcjTextLogParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(9, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(2), "Deprecation.java", Kind.WARNING, 7, 5, 30);
+        checkCompilerMessage(cm.get(3), "ExternalDeps.java", Kind.ERROR, 4, 8, 17);
+        checkCompilerMessage(cm.get(4), "ExternalDeps.java", Kind.ERROR, 12, 21, 31);
+        checkCompilerMessage(cm.get(5), "Info.java", Kind.NOTE, 5, 11, 11);
+        checkCompilerMessage(cm.get(6), "ReservedWord.java", Kind.ERROR, 5, 8, 13);
+        checkCompilerMessage(cm.get(7), "UnknownSymbol.java", Kind.ERROR, 7, 1, 3);
+        checkCompilerMessage(cm.get(8), "WrongClassname.java", Kind.ERROR, 3, 14, 27);
+    }
+
+    /**
+     * Test for example compiler output in non-XML format with errors reported as
+     * warnings.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParseErrorsAsWarnings() throws Exception {
+        File logFile = getTestFile(LOG_FILE_1);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjTextLogParser parser = new EcjTextLogParser();
+        List<CompilerMessage> cm = parser.parse(logFile, true);
+
+        assertEquals(9, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.WARNING, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.WARNING, 6, 1, 5);
+        checkCompilerMessage(cm.get(2), "Deprecation.java", Kind.WARNING, 7, 5, 30);
+        checkCompilerMessage(cm.get(3), "ExternalDeps.java", Kind.WARNING, 4, 8, 17);
+        checkCompilerMessage(cm.get(4), "ExternalDeps.java", Kind.WARNING, 12, 21, 31);
+        checkCompilerMessage(cm.get(5), "Info.java", Kind.NOTE, 5, 11, 11);
+        checkCompilerMessage(cm.get(6), "ReservedWord.java", Kind.WARNING, 5, 8, 13);
+        checkCompilerMessage(cm.get(7), "UnknownSymbol.java", Kind.WARNING, 7, 1, 3);
+        checkCompilerMessage(cm.get(8), "WrongClassname.java", Kind.WARNING, 3, 14, 27);
+    }
+
+    /**
+     * Test for ignoring output before first output delimiter.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testHeaderErrors() throws Exception {
+        File logFile = getTestFile(LOG_FILE_2);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjTextLogParser parser = new EcjTextLogParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(2, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Bad.java", Kind.ERROR, 6, 1, 5);
+        checkCompilerMessage(cm.get(1), "Bad.java", Kind.ERROR, 6, 1, 5);
+    }
+
+    /**
+     * Tests for parsing the contents of {@value #LOG_FILE_3}.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParse3() throws Exception {
+        File logFile = getTestFile(LOG_FILE_3);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjTextLogParser parser = new EcjTextLogParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(6, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "ECE.java", Kind.ERROR, 8, 13, 16);
+        checkCompilerMessage(cm.get(1), "ECE.java", Kind.ERROR, 16, 8, 40);
+        checkCompilerMessage(cm.get(2), "ECE.java", Kind.WARNING, 22, 9, 9);
+        checkCompilerMessage(cm.get(3), "ECE.java", Kind.WARNING, 27, 8, 40);
+        checkCompilerMessage(cm.get(4), "ECE.java", Kind.NOTE, 33, 13, 18);
+        checkCompilerMessage(cm.get(5), "ECE.java", Kind.NOTE, 35, 1, 95);
+    }
+
+    /**
+     * Tests for parsing the contents of {@value #LOG_FILE_4}.
+     *
+     * @throws Exception on test failure.
+     */
+    @Test
+    public void testParse4() throws Exception {
+        File logFile = getTestFile(LOG_FILE_4);
+        assertTrue(logFile.exists(), "Input log file missing");
+
+        EcjTextLogParser parser = new EcjTextLogParser();
+        List<CompilerMessage> cm = parser.parse(logFile, false);
+
+        assertEquals(1, cm.size(), "Wrong message count");
+
+        checkCompilerMessage(cm.get(0), "Column.java", Kind.ERROR, 2, 1, 5);
+    }
+
+    private void checkCompilerMessage(CompilerMessage cm, String file, Kind kind, int line, int startCol, int endCol) {
+        assertTrue(cm.getFile().endsWith(file), "Failure checking output for " + file);
+        assertEquals(kind, cm.getKind(), "Failure checking output for " + file);
+        assertEquals(line, cm.getStartLine(), "Failure checking output for " + file);
+        assertEquals(startCol, cm.getStartColumn(), "Failure checking output for " + file);
+        assertEquals(endCol, cm.getEndColumn(), "Failure checking output for " + file);
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerBasicTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerBasicTest.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+/**
+ * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public class EclipseCompilerBasicTest extends AbstractEclipseCompilerTest {
+    // Empty
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerConfigurationTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerConfigurationTest.java
@@ -1,5 +1,3 @@
-package org.codehaus.plexus.compiler.eclipse;
-
 /**
  * The MIT License
  *
@@ -23,6 +21,8 @@ package org.codehaus.plexus.compiler.eclipse;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.codehaus.plexus.compiler.eclipse;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class EclipseCompilerConfigurationTest {
@@ -98,10 +99,12 @@ public class EclipseCompilerConfigurationTest {
     @Test
     public void testProcessCustomArgumentsWithPropertiesAndNonExistingFile() {
         configuration.addCompilerCustomArgument("-properties", "fooBar.txt");
-        IllegalArgumentException expected = Assertions.assertThrows(
-                IllegalArgumentException.class,
+        EcjFailureException expected = Assertions.assertThrows(
+                EcjFailureException.class,
                 () -> EclipseJavaCompiler.processCustomArguments(configuration, Collections.emptyList()));
-        assertThat(expected.getMessage(), is("Properties file specified by -properties fooBar.txt does not exist"));
+        assertThat(
+                expected.getMessage(),
+                containsString("Properties file specified by -properties fooBar.txt does not exist"));
     }
 
     @Test

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerCustomArgumentTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerCustomArgumentTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.util.Collections;
+
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ */
+public class EclipseCompilerCustomArgumentTest extends AbstractEclipseCompilerTest {
+
+    @SuppressWarnings("unchecked")
+    public EclipseCompilerCustomArgumentTest() {
+        super(0, 0, 0, Collections.EMPTY_LIST);
+    }
+
+    @Override
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
+        super.configureCompilerConfig(compilerConfig);
+        compilerConfig.addCompilerCustomArgument("-key", "value");
+    }
+
+    @Test
+    @Override
+    public void testCompilingSources() throws Exception {
+        EcjFailureException exception = assertThrows(
+                EcjFailureException.class, super::testCompilingSources, "Compile should of thrown an exception");
+        assertTrue(
+                exception.getMessage().startsWith("Failed to run the ecj compiler: Unrecognized option : -key"),
+                "Unexpected compiler error");
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerDashedArgumentsTest.java
@@ -45,7 +45,7 @@ import static org.codehaus.plexus.testing.PlexusExtension.getBasedir;
 
 /**
  * @author <a href="mailto:jal@etc.to">Frits Jalvingh</a>
- * Created on 22-4-18.
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
  */
 @PlexusTest
 public class EclipseCompilerDashedArgumentsTest {

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerErrorsAsWarningsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerErrorsAsWarningsTest.java
@@ -1,16 +1,18 @@
 package org.codehaus.plexus.compiler.eclipse;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.codehaus.plexus.compiler.AbstractCompilerTest;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 
-public class EclipseCompilerErrorsAsWarningsTest extends AbstractCompilerTest {
+/**
+ * Test for errors being reported as warnings.
+ *
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public class EclipseCompilerErrorsAsWarningsTest extends AbstractEclipseCompilerTest {
 
-    protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
-        compilerConfig.addCompilerCustomArgument("-errorsAsWarnings", "true");
+    public EclipseCompilerErrorsAsWarningsTest() {
+        super(0, 6, 1);
     }
 
     @BeforeEach
@@ -24,27 +26,8 @@ public class EclipseCompilerErrorsAsWarningsTest extends AbstractCompilerTest {
         return "eclipse";
     }
 
-    @Override
-    protected int expectedErrors() {
-        return 0;
-    }
-
-    @Override
-    protected int expectedWarnings() {
-        return 6;
-    }
-
-    @Override
-    protected Collection<String> expectedOutputFiles() {
-        return Arrays.asList(
-                "org/codehaus/foo/Deprecation.class",
-                "org/codehaus/foo/ExternalDeps.class",
-                "org/codehaus/foo/Person.class",
-                "org/codehaus/foo/ReservedWord.class"
-                // "org/codehaus/foo/Bad.class",             // This one has no class file generated as it's one big
-                // issue
-                // "org/codehaus/foo/UnknownSymbol.class",
-                // "org/codehaus/foo/RightClassname.class"
-                );
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
+        super.configureCompilerConfig(compilerConfig);
+        compilerConfig.addCompilerCustomArgument("-errorsAsWarnings", "true");
     }
 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerFailOnWarningsTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerFailOnWarningsTest.java
@@ -1,13 +1,25 @@
 package org.codehaus.plexus.compiler.eclipse;
 
 import java.util.Arrays;
-import java.util.Collection;
 
-import org.codehaus.plexus.compiler.AbstractCompilerTest;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 
-public class EclipseCompilerFailOnWarningsTest extends AbstractCompilerTest {
+public class EclipseCompilerFailOnWarningsTest extends AbstractEclipseCompilerTest {
 
+    public EclipseCompilerFailOnWarningsTest() {
+        super(
+                4,
+                2,
+                1,
+                Arrays.asList(
+                        "org/codehaus/foo/Deprecation.class",
+                        "org/codehaus/foo/ExternalDeps.class",
+                        "org/codehaus/foo/Info.class",
+                        "org/codehaus/foo/Person.class",
+                        "org/codehaus/foo/ReservedWord.class"));
+    }
+
+    @Override
     protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
         compilerConfig.setFailOnWarning(true);
     }
@@ -15,24 +27,5 @@ public class EclipseCompilerFailOnWarningsTest extends AbstractCompilerTest {
     @Override
     protected String getRoleHint() {
         return "eclipse";
-    }
-
-    @Override
-    protected int expectedErrors() {
-        return 6;
-    }
-
-    @Override
-    protected int expectedWarnings() {
-        return 1;
-    }
-
-    @Override
-    protected Collection<String> expectedOutputFiles() {
-        return Arrays.asList(
-                "org/codehaus/foo/Deprecation.class",
-                "org/codehaus/foo/ExternalDeps.class",
-                "org/codehaus/foo/Person.class",
-                "org/codehaus/foo/ReservedWord.class");
     }
 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerInitializeWarningsForPropertiesArgumentTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerInitializeWarningsForPropertiesArgumentTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.util.Collections;
+
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ */
+public class EclipseCompilerInitializeWarningsForPropertiesArgumentTest extends AbstractEclipseCompilerTest {
+
+    @SuppressWarnings("unchecked")
+    public EclipseCompilerInitializeWarningsForPropertiesArgumentTest() {
+        super(0, 0, 0, Collections.EMPTY_LIST);
+    }
+
+    @Override
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {
+        super.configureCompilerConfig(compilerConfig);
+        compilerConfig.addCompilerCustomArgument("-properties", "file_does_not_exist");
+    }
+
+    @Test
+    @Override
+    public void testCompilingSources() throws Exception {
+        EcjFailureException exception = assertThrows(
+                EcjFailureException.class,
+                super::testCompilingSources,
+                "looking up the properties file should have thrown an exception");
+        assertTrue(
+                exception.getMessage().startsWith("Failed to run the ecj compiler: Properties file"),
+                "Unexpected compiler error");
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTest.java
@@ -23,22 +23,21 @@ package org.codehaus.plexus.compiler.eclipse;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import java.util.Arrays;
-import java.util.Collection;
-
-import org.codehaus.plexus.compiler.AbstractCompilerTest;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
  */
-public class EclipseCompilerTest extends AbstractCompilerTest {
+public class EclipseCompilerTest extends AbstractEclipseCompilerTest {
+    public EclipseCompilerTest() {
+        super(5, 1, 1);
+    }
 
     @BeforeEach
     public void setUp() {
@@ -49,25 +48,6 @@ public class EclipseCompilerTest extends AbstractCompilerTest {
     @Override
     protected String getRoleHint() {
         return "eclipse";
-    }
-
-    @Override
-    protected int expectedErrors() {
-        return 4;
-    }
-
-    @Override
-    protected int expectedWarnings() {
-        return 2;
-    }
-
-    @Override
-    protected Collection<String> expectedOutputFiles() {
-        return Arrays.asList(
-                "org/codehaus/foo/Deprecation.class",
-                "org/codehaus/foo/ExternalDeps.class",
-                "org/codehaus/foo/Person.class",
-                "org/codehaus/foo/ReservedWord.class");
     }
 
     // The test is fairly meaningless as we can not validate anything
@@ -86,9 +66,9 @@ public class EclipseCompilerTest extends AbstractCompilerTest {
 
         compilerConfig.addCompilerCustomArgument("-properties", "file_does_not_exist");
 
-        IllegalArgumentException e =
-                assertThrows(IllegalArgumentException.class, () -> getCompiler().performCompile(compilerConfig));
-        assertThat("Message must start with 'Properties file'", e.getMessage(), startsWith("Properties file"));
+        EcjFailureException e =
+                assertThrows(EcjFailureException.class, () -> getCompiler().performCompile(compilerConfig));
+        assertThat("Message must start with 'Properties file'", e.getMessage(), containsString("Properties file"));
     }
 
     private CompilerConfiguration createMinimalCompilerConfig() {

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTextLogTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerTextLogTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getTestPath;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test of a XML user log specified.
+ *
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public class EclipseCompilerTextLogTest extends AbstractEclipseCompilerTest {
+
+    private List<String> logFiles = new ArrayList<>();
+    private int idx = 0;
+
+    @Override
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig, String filename) {
+        super.configureCompilerConfig(compilerConfig, filename);
+        String logFile = getTestPath("/target/" + getRoleHint() + "/log-text-" + idx + ".log");
+        compilerConfig.addCompilerCustomArgument("-log", logFile);
+        idx++;
+    }
+
+    @Test
+    @Override
+    public void testCompilingSources() throws Exception {
+        super.testCompilingSources();
+        for (String file : logFiles) {
+            assertTrue(new File(file).exists());
+        }
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerXMLLogTest.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/java/org/codehaus/plexus/compiler/eclipse/EclipseCompilerXMLLogTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2005, The Codehaus
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.compiler.CompilerConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.codehaus.plexus.testing.PlexusExtension.getTestPath;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test of a XML user log specified.
+ *
+ * @author <a href="jfaust@tsunamit.com">Jason Faust</a>
+ * @since 2.14.0
+ */
+public class EclipseCompilerXMLLogTest extends AbstractEclipseCompilerTest {
+
+    private List<String> logFiles = new ArrayList<>();
+    private int idx = 0;
+
+    @Override
+    protected void configureCompilerConfig(CompilerConfiguration compilerConfig, String filename) {
+        super.configureCompilerConfig(compilerConfig, filename);
+        String logFile = getTestPath("/target/" + getRoleHint() + "/log-xml-" + idx + ".xml");
+        compilerConfig.addCompilerCustomArgument("-log", logFile);
+        idx++;
+    }
+
+    @Test
+    @Override
+    public void testCompilingSources() throws Exception {
+        super.testCompilingSources();
+        for (String file : logFiles) {
+            assertTrue(new File(file).exists());
+        }
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.txt
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.txt
@@ -1,0 +1,55 @@
+# 9/26/18 1:10:25 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+----------
+1. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java (at line 6)
+	pubic String name;
+	^^^^^
+Syntax error on token "pubic", public expected
+----------
+2. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java (at line 6)
+	pubic String name;
+	^^^^^
+pubic cannot be resolved to a type
+----------
+----------
+3. WARNING in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Deprecation.java (at line 7)
+	new java.util.Date("testDate");
+	    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+The constructor Date(String) is deprecated
+----------
+----------
+4. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\ExternalDeps.java (at line 4)
+	import org.apache.commons.lang.StringUtils;
+	       ^^^^^^^^^^
+The import org.apache cannot be resolved
+----------
+5. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\ExternalDeps.java (at line 12)
+	System.out.println( StringUtils.upperCase( str)  );
+	                    ^^^^^^^^^^^
+StringUtils cannot be resolved
+----------
+----------
+6. INFO in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Info.java (at line 5)
+	"".equals(1);
+	          ^
+Unlikely argument type for equals(): int seems to be unrelated to String
+----------
+----------
+7. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\ReservedWord.java (at line 5)
+	String assert;
+	       ^^^^^^
+Syntax error on token "assert", invalid VariableDeclarator
+----------
+----------
+8. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\UnknownSymbol.java (at line 7)
+	foo();
+	^^^
+The method foo() is undefined for the type UnknownSymbol
+----------
+----------
+9. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\WrongClassname.java (at line 3)
+	public class RightClassname
+	             ^^^^^^^^^^^^^^
+The public type RightClassname must be defined in its own file
+----------
+9 problems (7 errors, 1 warning, 1 info)

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/3.15.0.log.xml
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 9/26/18 1:10:13 PM EDT -->
+<!DOCTYPE compiler PUBLIC "-//Eclipse.org//DTD Eclipse JDT 3.2.005 Compiler//EN" "http://www.eclipse.org/jdt/core/compiler_32_005.dtd">
+<compiler copyright="Copyright IBM Corp 2000, 2015. All rights reserved." name="Eclipse Compiler for Java(TM)" version="v20180905-0317, 3.15.0">
+	<command_line>
+		<argument value="-8"/>
+		<argument value="-log"/>
+		<argument value="3.15.0.log.xml"/>
+		<argument value="src"/>
+	</command_line>
+	<options>
+		<option key="org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull" value="org.eclipse.jdt.annotation.NonNull"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault" value="org.eclipse.jdt.annotation.NonNullByDefault"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable" value="org.eclipse.jdt.annotation.Nullable"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullanalysis" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.lambda.genericSignature" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.methodParameters" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.shareCommonFinallyBlocks" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.unusedLocal" value="optimize out"/>
+		<option key="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.lineNumber" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.localVariable" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.sourceFile" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.doc.comment.support" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.emulateJavacBug8031744" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.generateClassFiles" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.maxProblemPerUnit" value="100"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.APILeak" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.annotationSuperInterface" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.autoboxing" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.comparingIdentical" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCode" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCodeInTrivialIfStatement" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationInDeprecatedCode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationWhenOverridingDeprecatedMethod" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.discouragedReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.emptyStatement" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fallthroughCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fatalOptionalError" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fieldHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finalParameterBound" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finallyBlockNotCompletingNormally" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.forbiddenReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.indirectStaticAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadoc" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTags" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsNotVisibleRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.localVariableHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.methodWithConstructorName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDefaultCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDeprecatedAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingEnumCaseDespiteDefault" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingHashCodeMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocComments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription" value="return_tag"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTags" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsMethodTypeParameters" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSerialVersion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSynchronizedOnInheritedMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noEffectAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noImplicitStringConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullParameterAnnotationDropped" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullTypeVariableFromLegacyInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullSpecViolation" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingMethodWithoutSuperInvocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingPackageDefaultMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.parameterAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentialNullReference" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.rawTypeReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSuperinterface" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBeStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.specialParameterHidingField" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.staticAccessReceiver" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressOptionalErrors" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressWarnings" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.tasks" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.terminalDeprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.typeParameterHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unclosedCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unhandledWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uninternedIdentityComparison" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentType" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType" value="info"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryElse" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unstableAutoModuleName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedImport" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLabel" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLocal" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenImplementingAbstract" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedPrivateMember" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeArgumentsForMethodInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.processAnnotations" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.release" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.storeAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskCaseSensitive" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskPriorities" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.taskTags" value=""/>
+	</options>
+	<classpaths>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\jsse.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\jce.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\resources.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\rt.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\charsets.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\access-bridge-64.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\cldrdata.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\dnsns.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\jaccess.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\localedata.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\nashorn.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunec.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunjce_provider.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunmscapi.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunpkcs11.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\zipfs.jar"/>
+		<classpath id="JAR" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\ecj-4.9.jar"/>
+	</classpaths>
+	<sources>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java">
+			<problems errors="2" infos="0" problems="2" warnings="0">
+				<problem categoryID="20" charEnd="101" charStart="97" id="ParsingError" line="6" problemID="1610612940" severity="ERROR">
+					<message value="Syntax error on token &quot;pubic&quot;, public expected"/>
+					<source_context sourceEnd="4" sourceStart="0" value="pubic String name;"/>
+					<arguments>
+						<argument value="pubic"/>
+						<argument value="public"/>
+					</arguments>
+				</problem>
+				<problem categoryID="40" charEnd="101" charStart="97" id="UndefinedType" line="6" problemID="16777218" severity="ERROR">
+					<message value="pubic cannot be resolved to a type"/>
+					<source_context sourceEnd="4" sourceStart="0" value="pubic String name;"/>
+					<arguments>
+						<argument value="pubic"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Deprecation.java">
+			<problems errors="0" infos="0" problems="1" warnings="1">
+				<problem categoryID="110" charEnd="122" charStart="97" id="UsingDeprecatedConstructor" line="7" optionKey="org.eclipse.jdt.core.compiler.problem.deprecation" problemID="134217861" severity="WARNING">
+					<message value="The constructor Date(String) is deprecated"/>
+					<source_context sourceEnd="29" sourceStart="4" value="new java.util.Date(&quot;testDate&quot;);"/>
+					<arguments>
+						<argument value="java.util.Date"/>
+						<argument value="java.lang.String"/>
+					</arguments>
+				</problem>
+			</problems>
+			<classfile path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Deprecation.class"/>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\ExternalDeps.java">
+			<problems errors="2" infos="0" problems="2" warnings="0">
+				<problem categoryID="30" charEnd="47" charStart="38" id="ImportNotFound" line="4" problemID="268435846" severity="ERROR">
+					<message value="The import org.apache cannot be resolved"/>
+					<source_context sourceEnd="16" sourceStart="7" value="import org.apache.commons.lang.StringUtils;"/>
+					<arguments>
+						<argument value="org.apache"/>
+					</arguments>
+				</problem>
+				<problem categoryID="50" charEnd="184" charStart="174" id="UndefinedName" line="12" problemID="570425394" severity="ERROR">
+					<message value="StringUtils cannot be resolved"/>
+					<source_context sourceEnd="30" sourceStart="20" value="System.out.println( StringUtils.upperCase( str)  );"/>
+					<arguments>
+						<argument value="StringUtils"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Info.java">
+			<problems errors="0" infos="1" problems="0" warnings="0">
+				<problem categoryID="90" charEnd="75" charStart="75" id="UnlikelyEqualsArgumentType" line="5" optionKey="org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType" problemID="1201" severity="INFO">
+					<message value="Unlikely argument type for equals(): int seems to be unrelated to String"/>
+					<source_context sourceEnd="10" sourceStart="10" value="&quot;&quot;.equals(1);"/>
+					<arguments>
+						<argument value="int"/>
+						<argument value="equals(Object)"/>
+						<argument value="java.lang.String"/>
+					</arguments>
+				</problem>
+			</problems>
+			<classfile path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Info.class"/>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Person.java">
+			<classfile path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Person.class"/>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\ReservedWord.java">
+			<problems errors="1" infos="0" problems="1" warnings="0">
+				<problem categoryID="20" charEnd="72" charStart="67" id="ParsingErrorInvalidToken" line="5" problemID="1610612971" severity="ERROR">
+					<message value="Syntax error on token &quot;assert&quot;, invalid VariableDeclarator"/>
+					<source_context sourceEnd="12" sourceStart="7" value="String assert;"/>
+					<arguments>
+						<argument value="assert"/>
+						<argument value="VariableDeclarator"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\UnknownSymbol.java">
+			<problems errors="1" infos="0" problems="1" warnings="0">
+				<problem categoryID="50" charEnd="105" charStart="103" id="UndefinedMethod" line="7" problemID="67108964" severity="ERROR">
+					<message value="The method foo() is undefined for the type UnknownSymbol"/>
+					<source_context sourceEnd="2" sourceStart="0" value="foo();"/>
+					<arguments>
+						<argument value="org.codehaus.foo.UnknownSymbol"/>
+						<argument value="foo"/>
+						<argument value=""/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+		<source package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\WrongClassname.java">
+			<problems errors="1" infos="0" problems="1" warnings="0">
+				<problem categoryID="40" charEnd="55" charStart="42" id="PublicClassMustMatchFileName" line="3" problemID="16777541" severity="ERROR">
+					<message value="The public type RightClassname must be defined in its own file"/>
+					<source_context sourceEnd="26" sourceStart="13" value="public class RightClassname"/>
+					<arguments>
+						<argument value="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\WrongClassname.java"/>
+						<argument value="RightClassname"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+	</sources>
+	<stats>
+		<problem_summary errors="7" infos="1" problems="9" tasks="0" warnings="1"/>
+	</stats>
+</compiler>

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.txt
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.txt
@@ -1,0 +1,9 @@
+# 10/29/18, 3:53:36 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+----------
+1. ERROR in C:\TEMP\Column.java (at line 2)
+	12345
+	^^^^^
+Syntax error on token "12345", delete this token
+----------
+1 problem (1 error)

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-columns.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 10/29/18, 3:53:40 PM EDT -->
+<!DOCTYPE compiler PUBLIC "-//Eclipse.org//DTD Eclipse JDT 3.2.005 Compiler//EN" "http://www.eclipse.org/jdt/core/compiler_32_005.dtd">
+<compiler copyright="Copyright IBM Corp 2000, 2015. All rights reserved." name="Eclipse Compiler for Java(TM)" version="v20180905-0317, 3.15.0">
+	<command_line>
+		<argument value="Column.java"/>
+		<argument value="-log"/>
+		<argument value="eclipse-columns.xml"/>
+	</command_line>
+	<options>
+		<option key="org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull" value="org.eclipse.jdt.annotation.NonNull"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault" value="org.eclipse.jdt.annotation.NonNullByDefault"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable" value="org.eclipse.jdt.annotation.Nullable"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullanalysis" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.lambda.genericSignature" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.methodParameters" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.shareCommonFinallyBlocks" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.2"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.unusedLocal" value="optimize out"/>
+		<option key="org.eclipse.jdt.core.compiler.compliance" value="1.4"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.lineNumber" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.localVariable" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.sourceFile" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.doc.comment.support" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.emulateJavacBug8031744" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.generateClassFiles" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.maxProblemPerUnit" value="100"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.APILeak" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.annotationSuperInterface" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.autoboxing" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.comparingIdentical" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCode" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCodeInTrivialIfStatement" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationInDeprecatedCode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationWhenOverridingDeprecatedMethod" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.discouragedReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.emptyStatement" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fallthroughCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fatalOptionalError" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fieldHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finalParameterBound" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finallyBlockNotCompletingNormally" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.forbiddenReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.indirectStaticAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadoc" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTags" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsNotVisibleRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.localVariableHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.methodWithConstructorName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDefaultCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDeprecatedAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingEnumCaseDespiteDefault" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingHashCodeMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocComments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription" value="return_tag"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTags" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsMethodTypeParameters" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSerialVersion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSynchronizedOnInheritedMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noEffectAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noImplicitStringConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullParameterAnnotationDropped" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullTypeVariableFromLegacyInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullSpecViolation" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingMethodWithoutSuperInvocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingPackageDefaultMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.parameterAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentialNullReference" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.rawTypeReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSuperinterface" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBeStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.specialParameterHidingField" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.staticAccessReceiver" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressOptionalErrors" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressWarnings" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.tasks" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.terminalDeprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.typeParameterHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unclosedCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unhandledWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uninternedIdentityComparison" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentType" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType" value="info"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryElse" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unstableAutoModuleName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedImport" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLabel" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLocal" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenImplementingAbstract" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedPrivateMember" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeArgumentsForMethodInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.processAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.release" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.source" value="1.3"/>
+		<option key="org.eclipse.jdt.core.compiler.storeAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskCaseSensitive" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskPriorities" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.taskTags" value=""/>
+	</options>
+	<classpaths>
+		<classpath id="FOLDER" path="C:\devenv\java\jdk-10.0.2"/>
+		<classpath id="JAR" path="C:\devenv\maven\local-repo\org\eclipse\jdt\ecj\3.15.0\ecj-3.15.0.jar"/>
+	</classpaths>
+	<sources>
+		<source path="C:\TEMP\Column.java">
+			<problems errors="1" infos="0" problems="1" warnings="0">
+				<problem categoryID="20" charEnd="27" charStart="23" id="ParsingErrorDeleteToken" line="2" problemID="1610612968" severity="ERROR">
+					<message value="Syntax error on token &quot;12345&quot;, delete this token"/>
+					<source_context sourceEnd="4" sourceStart="0" value="12345"/>
+					<arguments>
+						<argument value="12345"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+	</sources>
+	<stats>
+		<problem_summary errors="1" infos="0" problems="1" tasks="0" warnings="0"/>
+	</stats>
+</compiler>

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.txt
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.txt
@@ -1,0 +1,42 @@
+# 10/15/18, 2:50:59 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+----------
+1. ERROR in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 8)
+	Integer x = 0.0f;
+	            ^^^^
+Type mismatch: cannot convert from float to Integer
+----------
+2. ERROR in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 16)
+	} else {
+            x = 20;
+        }
+	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Dead code
+----------
+3. WARNING in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 22)
+	Integer x;
+	        ^
+The value of the local variable x is not used
+----------
+4. WARNING in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 27)
+	} else {
+            x = 30;
+        }
+	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Statement unnecessarily nested within else clause. The corresponding then clause does not complete normally
+----------
+5. INFO in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 33)
+	Boolean x = 7 == 7;
+	            ^^^^^^
+Comparing identical expressions
+----------
+6. INFO in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 35)
+	new Object() {
+            {
+                System.out.println(x);
+            }
+        };
+	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The allocated object is never used
+----------
+6 problems (2 errors, 2 warnings, 2 info)

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/eclipse-withinfo.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 10/15/18, 2:50:22 PM EDT -->
+<!DOCTYPE compiler PUBLIC "-//Eclipse.org//DTD Eclipse JDT 3.2.005 Compiler//EN" "http://www.eclipse.org/jdt/core/compiler_32_005.dtd">
+<compiler copyright="Copyright IBM Corp 2000, 2015. All rights reserved." name="Eclipse Compiler for Java(TM)" version="v20180905-0317, 3.15.0">
+	<command_line>
+		<argument value="-noExit"/>
+		<argument value="-preserveAllLocals"/>
+		<argument value="-g:lines,vars,source"/>
+		<argument value="-source"/>
+		<argument value="1.6"/>
+		<argument value="-target"/>
+		<argument value="1.6"/>
+		<argument value="-encoding"/>
+		<argument value="UTF-8"/>
+		<argument value="-warn:none"/>
+		<argument value="-annotationpath"/>
+		<argument value="CLASSPATH"/>
+		<argument value="-log"/>
+		<argument value="C:\devenv\workspace\x\y\target/jdt-compile.xml"/>
+		<argument value="-properties"/>
+		<argument value="C:\devenv\workspace\x\y/.settings/org.eclipse.jdt.core.prefs"/>
+		<argument value="-d"/>
+		<argument value="C:\devenv\workspace\x\y\target\classes"/>
+		<argument value="-classpath"/>
+		<argument value="C:\devenv\workspace\x\y\target\classes;C:\devenv\maven\local-repo\com\github\spotbugs\spotbugs-annotations\3.1.7\spotbugs-annotations-3.1.7.jar;C:\devenv\maven\local-repo\org\eclipse\jdt\org.eclipse.jdt.annotation\2.2.100\org.eclipse.jdt.annotation-2.2.100.jar;C:\devenv\workspace\x\y\target\classes;"/>
+		<argument value="C:\devenv\workspace\x\y\src\main\java\y\package-info.java"/>
+		<argument value="C:\devenv\workspace\x\y\src\main\java\y\ECE.java"/>
+	</command_line>
+	<options>
+		<option key="org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull" value="org.eclipse.jdt.annotation.NonNull"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault" value="org.eclipse.jdt.annotation.NonNullByDefault"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable" value="org.eclipse.jdt.annotation.Nullable"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullanalysis" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.lambda.genericSignature" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.methodParameters" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.shareCommonFinallyBlocks" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="10"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.unusedLocal" value="preserve"/>
+		<option key="org.eclipse.jdt.core.compiler.compliance" value="10"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.lineNumber" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.localVariable" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.sourceFile" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.doc.comment.support" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.emulateJavacBug8031744" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.generateClassFiles" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.maxProblemPerUnit" value="100"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.APILeak" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.annotationSuperInterface" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.autoboxing" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.comparingIdentical" value="info"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCode" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCodeInTrivialIfStatement" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationInDeprecatedCode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationWhenOverridingDeprecatedMethod" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.discouragedReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.emptyStatement" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fallthroughCase" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fatalOptionalError" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fieldHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finalParameterBound" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finallyBlockNotCompletingNormally" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.forbiddenReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.indirectStaticAccess" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadoc" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTags" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsNotVisibleRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsVisibility" value="default"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.localVariableHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.methodWithConstructorName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDefaultCase" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDeprecatedAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingEnumCaseDespiteDefault" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingHashCodeMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocComments" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsVisibility" value="default"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription" value="all_standard_tags"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTags" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsMethodTypeParameters" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsVisibility" value="default"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSerialVersion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSynchronizedOnInheritedMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noEffectAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noImplicitStringConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullParameterAnnotationDropped" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullTypeVariableFromLegacyInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullReference" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullSpecViolation" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingMethodWithoutSuperInvocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingPackageDefaultMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.parameterAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentialNullReference" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.rawTypeReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullCheck" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSuperinterface" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBeStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.specialParameterHidingField" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.staticAccessReceiver" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressOptionalErrors" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressWarnings" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.tasks" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.terminalDeprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.typeParameterHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unclosedCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unhandledWarningToken" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uninternedIdentityComparison" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentType" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryElse" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unstableAutoModuleName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedImport" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLabel" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLocal" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation" value="info"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameter" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenImplementingAbstract" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedPrivateMember" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeArgumentsForMethodInvocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeParameter" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.processAnnotations" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.release" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.source" value="10"/>
+		<option key="org.eclipse.jdt.core.compiler.storeAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskCaseSensitive" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskPriorities" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.taskTags" value=""/>
+		<option key="org.eclipse.jdt.core.encoding" value="UTF-8"/>
+	</options>
+	<classpaths>
+		<classpath id="FOLDER" path="C:\devenv\java\jdk-10.0.2"/>
+		<classpath id="FOLDER" path="C:\devenv\workspace\x\y\target\classes\"/>
+		<classpath id="JAR" path="C:\devenv\maven\local-repo\com\github\spotbugs\spotbugs-annotations\3.1.7\spotbugs-annotations-3.1.7.jar"/>
+		<classpath id="JAR" path="C:\devenv\maven\local-repo\org\eclipse\jdt\org.eclipse.jdt.annotation\2.2.100\org.eclipse.jdt.annotation-2.2.100.jar"/>
+	</classpaths>
+	<sources>
+		<source output="C:\devenv\workspace\x\y\target\classes" package="y" path="C:\devenv\workspace\x\y\src\main\java\y\package-info.java">
+			<classfile path="C:\devenv\workspace\x\y\target\classes\y\package-info.class"/>
+		</source>
+		<source output="C:\devenv\workspace\x\y\target\classes" package="y" path="C:\devenv\workspace\x\y\src\main\java\y\ECE.java">
+			<problems errors="2" infos="2" problems="4" warnings="2">
+				<problem categoryID="40" charEnd="126" charStart="123" id="TypeMismatch" line="8" problemID="16777233" severity="ERROR">
+					<message value="Type mismatch: cannot convert from float to Integer"/>
+					<source_context sourceEnd="15" sourceStart="12" value="Integer x = 0.0f;"/>
+					<arguments>
+						<argument value="float"/>
+						<argument value="java.lang.Integer"/>
+					</arguments>
+				</problem>
+				<problem categoryID="90" charEnd="278" charStart="246" id="DeadCode" line="16" optionKey="org.eclipse.jdt.core.compiler.problem.deadCode" problemID="536871061" severity="ERROR">
+					<message value="Dead code"/>
+					<source_context sourceEnd="39" sourceStart="7" value="} else {
+            x = 20;
+        }"/>
+				</problem>
+				<problem categoryID="120" charEnd="335" charStart="335" id="LocalVariableIsNeverUsed" line="22" optionKey="org.eclipse.jdt.core.compiler.problem.unusedLocal" problemID="536870973" severity="WARNING">
+					<message value="The value of the local variable x is not used"/>
+					<source_context sourceEnd="8" sourceStart="8" value="Integer x;"/>
+					<arguments>
+						<argument value="x"/>
+					</arguments>
+				</problem>
+				<problem categoryID="120" charEnd="464" charStart="432" id="UnnecessaryElse" line="27" optionKey="org.eclipse.jdt.core.compiler.problem.unnecessaryElse" problemID="536871101" severity="WARNING">
+					<message value="Statement unnecessarily nested within else clause. The corresponding then clause does not complete normally"/>
+					<source_context sourceEnd="39" sourceStart="7" value="} else {
+            x = 30;
+        }"/>
+				</problem>
+				<problem categoryID="90" charEnd="527" charStart="522" id="ComparingIdentical" line="33" optionKey="org.eclipse.jdt.core.compiler.problem.comparingIdentical" problemID="536871123" severity="INFO">
+					<message value="Comparing identical expressions"/>
+					<source_context sourceEnd="17" sourceStart="12" value="Boolean x = 7 == 7;"/>
+				</problem>
+				<problem categoryID="90" charEnd="635" charStart="541" id="UnusedObjectAllocation" line="35" optionKey="org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation" problemID="536871060" severity="INFO">
+					<message value="The allocated object is never used"/>
+					<source_context sourceEnd="94" sourceStart="0" value="new Object() {
+            {
+                System.out.println(x);
+            }
+        };"/>
+				</problem>
+			</problems>
+		</source>
+	</sources>
+	<stats>
+		<problem_summary errors="2" infos="2" problems="6" tasks="0" warnings="2"/>
+	</stats>
+</compiler>

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/log-text-0.log
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/log-text-0.log
@@ -1,0 +1,15 @@
+# 9/26/18 4:37:25 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+incorrect classpath: C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse/target/eclipse/classes-0
+----------
+1. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java (at line 6)
+	pubic String name;
+	^^^^^
+Syntax error on token "pubic", public expected
+----------
+2. ERROR in C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java (at line 6)
+	pubic String name;
+	^^^^^
+pubic cannot be resolved to a type
+----------
+2 problems (2 errors)

--- a/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/log-xml-0.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test/resources/org/codehaus/plexus/compiler/eclipse/log-xml-0.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 9/26/18 4:34:48 PM EDT -->
+<!DOCTYPE compiler PUBLIC "-//Eclipse.org//DTD Eclipse JDT 3.2.005 Compiler//EN" "http://www.eclipse.org/jdt/core/compiler_32_005.dtd">
+<compiler copyright="Copyright IBM Corp 2000, 2015. All rights reserved." name="Eclipse Compiler for Java(TM)" version="v20180905-0317, 3.15.0">
+	<command_line>
+		<argument value="-noExit"/>
+		<argument value="-preserveAllLocals"/>
+		<argument value="-g:lines,vars,source"/>
+		<argument value="-source"/>
+		<argument value="1.8"/>
+		<argument value="-target"/>
+		<argument value="1.8"/>
+		<argument value="-warn:+deprecation"/>
+		<argument value="-log"/>
+		<argument value="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\target\eclipse\log-xml-0.xml"/>
+		<argument value="-d"/>
+		<argument value="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse/target/eclipse/classes-0"/>
+		<argument value="-classpath"/>
+		<argument value="C:\devenv\maven\local-repo\commons-lang\commons-lang\2.0\commons-lang-2.0.jar;C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse/target/eclipse/classes-0;"/>
+		<argument value="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java"/>
+	</command_line>
+	<options>
+		<option key="org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull" value="org.eclipse.jdt.annotation.NonNull"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnull.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault" value="org.eclipse.jdt.annotation.NonNullByDefault"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable" value="org.eclipse.jdt.annotation.Nullable"/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullable.secondary" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.annotation.nullanalysis" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.lambda.genericSignature" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.methodParameters" value="do not generate"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.shareCommonFinallyBlocks" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.codegen.unusedLocal" value="preserve"/>
+		<option key="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.lineNumber" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.localVariable" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.debug.sourceFile" value="generate"/>
+		<option key="org.eclipse.jdt.core.compiler.doc.comment.support" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.emulateJavacBug8031744" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.generateClassFiles" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.maxProblemPerUnit" value="100"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.APILeak" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.annotationSuperInterface" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.autoboxing" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.comparingIdentical" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCode" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deadCodeInTrivialIfStatement" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationInDeprecatedCode" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.deprecationWhenOverridingDeprecatedMethod" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.discouragedReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.emptyStatement" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fallthroughCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fatalOptionalError" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.fieldHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finalParameterBound" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.finallyBlockNotCompletingNormally" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.forbiddenReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.indirectStaticAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadoc" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTags" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsNotVisibleRef" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.localVariableHiding" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.methodWithConstructorName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDefaultCase" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingDeprecatedAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingEnumCaseDespiteDefault" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingHashCodeMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocComments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription" value="return_tag"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTags" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsMethodTypeParameters" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingJavadocTagsVisibility" value="public"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotationForInterfaceMethodImplementation" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSerialVersion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.missingSynchronizedOnInheritedMethod" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noEffectAssignment" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.noImplicitStringConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullParameterAnnotationDropped" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nonnullTypeVariableFromLegacyInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullSpecViolation" value="error"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingMethodWithoutSuperInvocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.overridingPackageDefaultMethod" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.parameterAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentialNullReference" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.rawTypeReference" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantNullCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.redundantSuperinterface" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.reportMethodCanBeStatic" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.specialParameterHidingField" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.staticAccessReceiver" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressOptionalErrors" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.suppressWarnings" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.tasks" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.terminalDeprecation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.typeParameterHiding" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unavoidableGenericTypeProblems" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uncheckedTypeOperation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unclosedCloseable" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unhandledWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.uninternedIdentityComparison" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentType" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType" value="info"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryElse" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unstableAutoModuleName" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverriding" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedImport" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLabel" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedLocal" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenImplementingAbstract" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedParameterWhenOverridingConcrete" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedPrivateMember" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeArgumentsForMethodInvocation" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedTypeParameter" value="ignore"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.unusedWarningToken" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.problem.varargsArgumentNeedCast" value="warning"/>
+		<option key="org.eclipse.jdt.core.compiler.processAnnotations" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.release" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+		<option key="org.eclipse.jdt.core.compiler.storeAnnotations" value="disabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskCaseSensitive" value="enabled"/>
+		<option key="org.eclipse.jdt.core.compiler.taskPriorities" value=""/>
+		<option key="org.eclipse.jdt.core.compiler.taskTags" value=""/>
+	</options>
+	<classpaths>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\jce.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\charsets.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\rt.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\resources.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\jsse.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\access-bridge-64.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\cldrdata.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\dnsns.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\jaccess.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\localedata.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\nashorn.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunec.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunjce_provider.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunmscapi.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\sunpkcs11.jar"/>
+		<classpath id="JAR" path="C:\devenv\java\jdk8u172-b11\jre\lib\ext\zipfs.jar"/>
+		<classpath id="JAR" path="C:\devenv\maven\local-repo\commons-lang\commons-lang\2.0\commons-lang-2.0.jar"/>
+	</classpaths>
+	<error message="incorrect classpath: C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse/target/eclipse/classes-0"/>
+	<sources>
+		<source output="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\target\eclipse\classes-0" package="org\codehaus\foo" path="C:\devenv\gitrepo\plexus-compiler\plexus-compilers\plexus-compiler-eclipse\src\test-input\src\main\org\codehaus\foo\Bad.java">
+			<problems errors="2" infos="0" problems="2" warnings="0">
+				<problem categoryID="20" charEnd="101" charStart="97" id="ParsingError" line="6" problemID="1610612940" severity="ERROR">
+					<message value="Syntax error on token &quot;pubic&quot;, public expected"/>
+					<source_context sourceEnd="4" sourceStart="0" value="pubic String name;"/>
+					<arguments>
+						<argument value="pubic"/>
+						<argument value="public"/>
+					</arguments>
+				</problem>
+				<problem categoryID="40" charEnd="101" charStart="97" id="UndefinedType" line="6" problemID="16777218" severity="ERROR">
+					<message value="pubic cannot be resolved to a type"/>
+					<source_context sourceEnd="4" sourceStart="0" value="pubic String name;"/>
+					<arguments>
+						<argument value="pubic"/>
+					</arguments>
+				</problem>
+			</problems>
+		</source>
+	</sources>
+	<stats>
+		<problem_summary errors="2" infos="0" problems="2" tasks="0" warnings="0"/>
+	</stats>
+</compiler>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/src/test/java/org/codehaus/plexus/compiler/javac/JavacErrorProneCompilerTest.java
@@ -17,10 +17,11 @@ public class JavacErrorProneCompilerTest extends AbstractCompilerTest {
         String javaVersion = getJavaVersion();
         if (javaVersion.startsWith("1.8")) {
             return 1;
-        } else if (javaVersion.contains("18") || javaVersion.contains("19") || javaVersion.contains("20")) {
+        } else if (javaVersion.contains("18")
+                || javaVersion.contains("19")
+                || javaVersion.contains("20")
+                || javaVersion.contains("21")) {
             return 5;
-        } else if (javaVersion.contains("21")) {
-            return 6;
         }
         return 2;
     }
@@ -28,6 +29,15 @@ public class JavacErrorProneCompilerTest extends AbstractCompilerTest {
     @Override
     protected int expectedErrors() {
         return 1;
+    }
+
+    @Override
+    protected int expectedNotes() {
+        String javaVersion = getJavaVersion();
+        if (javaVersion.contains("21")) {
+            return 1;
+        }
+        return 0;
     }
 
     @Override

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -697,7 +697,7 @@ public class JavacCompiler extends AbstractCompiler {
             } else if ((buffer.length() == 0) && line.startsWith("warning: ")) {
                 errors.add(new CompilerMessage(line, CompilerMessage.Kind.WARNING));
             } else if ((buffer.length() == 0) && isNote(line)) {
-                // skip, JDK 1.5 telling us deprecated APIs are used but -Xlint:deprecation isn't set
+                errors.add(new CompilerMessage(line, CompilerMessage.Kind.NOTE));
             } else if ((buffer.length() == 0) && isMisc(line)) {
                 // verbose output was set
                 errors.add(new CompilerMessage(line, CompilerMessage.Kind.OTHER));

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -111,6 +111,15 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
     }
 
     @Override
+    protected int expectedNotes() {
+        String javaVersion = getJavaVersion();
+        if (javaVersion.contains("21")) {
+            return 7;
+        }
+        return 0;
+    }
+
+    @Override
     public String getTargetVersion() {
         String javaVersion = getJavaVersion();
         if (javaVersion.contains("9.0")) {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -117,6 +117,16 @@ public class ErrorMessageParserTest {
     }
 
     @Test
+    public void testNoteMessage() throws IOException {
+        String error = "Note: My fancy annotation processor info" + EOL;
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(error)));
+        assertThat(messages.size(), is(1));
+        assertThat(messages.get(0).isError(), is(false));
+        assertThat(messages.get(0).getMessage(), is("My fancy annotation processor info"));
+    }
+
+    @Test
     public void testUnknownSymbolError() {
         String error = "./org/codehaus/foo/UnknownSymbol.java:7: cannot find symbol" + EOL + "symbol  : method foo()"
                 + EOL + "location: class org.codehaus.foo.UnknownSymbol"

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
@@ -24,13 +24,4 @@ package org.codehaus.plexus.compiler.javac;
 public class JavaxToolsCompilerTest extends AbstractJavacCompilerTest {
     // no op default is to javax.tools if available
 
-    @Override
-    protected int expectedWarnings() {
-        String javaVersion = getJavaVersion();
-        if (javaVersion.contains("21")) {
-            return 8;
-        } else {
-            return super.expectedWarnings();
-        }
-    }
 }


### PR DESCRIPTION
- #313 
- #314 
- Parse and forward JavaC Note messages (supersedes #288)
- Allow -log argument for Eclipse compiler (supersedes #57)
- Fixes #183 and #55

Theses messages can be generated by annotation processors using
`printMessage(Diagnostic.Kind.NOTE, "...")`.
