### PR TITLE
Add dependency to plexus-compiler-eclipse in ITs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,5 +30,5 @@ jobs:
       jdk-matrix: '["11", "17", "21"]'
       jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica", "corretto"]'
       os-matrix: '["ubuntu-latest","windows-latest", "macOS-latest"]'
-      maven_args: 'install javadoc:javadoc -e -B -V -fae -Pno-tests-if-not-on-osx'
+      maven_args: 'verify javadoc:javadoc -e -B -V -fae -Pno-tests-if-not-on-osx'
 

--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -26,6 +26,10 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-compiler-eclipse</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-compiler-javac</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-compiler-eclipse</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-compiler-javac-errorprone</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
ITs use plexus-compiler-eclipse so should be on dependencies list 

We should use in tests artifact from current build execution, 
not one installed in local repository