### PR TITLE
Include 'parameter' and 'preview' describe log

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -688,14 +688,17 @@ public class CompilerConfiguration {
                 params.add("debug");
             }
         }
-        if (isOptimize()) {
-            params.add("optimize");
-        }
         if (isVerbose()) {
             params.add("verbose");
         }
         if (isShowDeprecation()) {
             params.add("deprecation");
+        }
+        if (isParameters()) {
+            params.add("parameters");
+        }
+        if (isEnablePreview()) {
+            params.add("preview");
         }
 
         // target bytecode options: release or target, module-path


### PR DESCRIPTION
The `-parameter` and `--enable-preview` compiler options affect the output of the generated classes, so it's helpful to see if those options are enabled.

This also removes the `optimize` option as in the maven-compiler-plugin this is deprecated.