### PR TITLE
Disable J2ObjC testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,5 +30,5 @@ jobs:
       jdk-matrix: '["11", "17", "21"]'
       jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica", "corretto"]'
       os-matrix: '["ubuntu-latest","windows-latest", "macOS-latest"]'
-      maven_args: 'verify javadoc:javadoc -e -B -V -fae -Pno-tests-if-not-on-osx'
+      maven_args: 'verify javadoc:javadoc -e -B -V -fae'
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,3 @@ This component is an Compilation API used by Apache Maven Compiler plugin on the
 Please refer to [documentation](https://errorprone.info/docs/installation#maven) 
 
 Or the project [it test](plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml)
-
-### J2ObjC OSX
-
-To compile this project on OSX, you need to have J2ObjC installed: [J2ObjC Requirements](https://developers.google.com/j2objc#requirements).

--- a/plexus-compilers/plexus-compiler-j2objc/pom.xml
+++ b/plexus-compilers/plexus-compiler-j2objc/pom.xml
@@ -34,25 +34,19 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>no-tests-if-not-on-osx</id>
-      <activation>
-        <os>
-          <family>!mac</family>
-        </os>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- test require MacOS and external software J2ObjC -->
+          <!-- J2ObjC support max JDK 11 -->
+          <!-- if needed we should fix test to be OS independent -->
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
- test require MacOS and external software J2ObjC
- J2ObjC support max JDK 11
- if needed we should fix test to be OS independent
- it is also disabled on GitHub build