### PR TITLE
Require JDK 17 for build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build it
-    uses: codehaus-plexus/.github/.github/workflows/maven.yml@mvn-setup
+    uses: codehaus-plexus/.github/.github/workflows/maven.yml@master
     with:
       matrix-exclude: '[ {"jdk": "8"}, {"jdk": "11"} ]'
       jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica", "corretto"]'
@@ -31,5 +31,5 @@ jobs:
   deploy:
     name: Deploy
     needs: build
-    uses: codehaus-plexus/.github/.github/workflows/maven-deploy.yml@mvn-setup
+    uses: codehaus-plexus/.github/.github/workflows/maven-deploy.yml@master
     secrets: inherit

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build it
-    uses: codehaus-plexus/.github/.github/workflows/maven.yml@master
+    uses: codehaus-plexus/.github/.github/workflows/maven.yml@mvn-setup
     with:
       matrix-exclude: '[ {"jdk": "8"}, {"jdk": "11"} ]'
       jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica", "corretto"]'
@@ -31,5 +31,5 @@ jobs:
   deploy:
     name: Deploy
     needs: build
-    uses: codehaus-plexus/.github/.github/workflows/maven-deploy.yml@master
+    uses: codehaus-plexus/.github/.github/workflows/maven-deploy.yml@mvn-setup
     secrets: inherit

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build it
     uses: codehaus-plexus/.github/.github/workflows/maven.yml@master
     with:
-      matrix-exclude: '[  {"jdk": "8"} ]'
+      matrix-exclude: '[ {"jdk": "8"}, {"jdk": "11"} ]'
       jdk-distribution-matrix: '["zulu", "temurin", "microsoft", "liberica", "corretto"]'
       maven_args: 'verify javadoc:javadoc -e -B -V -fae'
 

--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <junit.version>4.13.2</junit.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <javaVersion>17</javaVersion>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 

--- a/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/invoker.properties
+++ b/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 11+
 invoker.goals = clean compile
 invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/invoker.properties
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
 invoker.goals = clean test
 #invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/invoker.properties
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/invoker.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
+invoker.maven.version = 3.9.6+
 
 # without-dummy profile is used to have compiler plugin do actual compilation in the second run
 invoker.name.1 = Initial build

--- a/plexus-compiler-its/src/main/it/error-prone-compiler/invoker.properties
+++ b/plexus-compiler-its/src/main/it/error-prone-compiler/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
 invoker.goals = clean test-compile
 invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/missing-warnings/invoker.properties
+++ b/plexus-compiler-its/src/main/it/missing-warnings/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 11+
 invoker.goals = clean compile
 #invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/simple-eclipse-compiler-fail/invoker.properties
+++ b/plexus-compiler-its/src/main/it/simple-eclipse-compiler-fail/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
 invoker.goals = clean test-compile
 invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/simple-eclipse-compiler/invoker.properties
+++ b/plexus-compiler-its/src/main/it/simple-eclipse-compiler/invoker.properties
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
+invoker.maven.version = 3.9.6+
+
 invoker.goals = clean test-compile
 #invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/simple-javac-fork/invoker.properties
+++ b/plexus-compiler-its/src/main/it/simple-javac-fork/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
 invoker.goals = clean test-compile
 #invoker.buildResult = failure

--- a/plexus-compiler-its/src/main/it/simple-javac-fork/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-javac-fork/pom.xml
@@ -32,8 +32,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
-    <plexus.compiler.version>@pom.version@</plexus.compiler.version>
+    <javaVersion>11</javaVersion>
+    <plexus.compiler.version>@project.version@</plexus.compiler.version>
   </properties>
 
   <dependencies>

--- a/plexus-compiler-its/src/main/it/simple-javac/invoker.properties
+++ b/plexus-compiler-its/src/main/it/simple-javac/invoker.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.java.version = 1.8+
 invoker.goals = clean test-compile
 #invoker.buildResult = failure

--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -14,7 +14,7 @@
   <description>AspectJ Compiler support for Plexus Compiler component.</description>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <javaVersion>11</javaVersion>
   </properties>
 
   <dependencies>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -14,7 +14,7 @@
   <description>Eclipse Compiler support for Plexus Compiler component.</description>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <javaVersion>17</javaVersion>
   </properties>
 
   <dependencies>

--- a/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
+++ b/plexus-compilers/plexus-compiler-javac-errorprone/pom.xml
@@ -16,7 +16,7 @@
     See https://errorprone.info</description>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <javaVersion>11</javaVersion>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,7 @@
 
   <properties>
     <scm.url>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</scm.url>
-    <javaVersion>11</javaVersion>
-    <maven.compiler.release>8</maven.compiler.release>
+    <javaVersion>8</javaVersion>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2022-12-17T17:23:49Z</project.build.outputTimestamp>
     <jupiter.version>5.10.1</jupiter.version>
@@ -190,13 +189,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.4.1</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.7.0</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -206,24 +198,10 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11,)</version>
-                  <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 11 or newer</message>
+                  <version>[17,)</version>
+                  <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 17 or newer</message>
                 </requireJavaVersion>
               </rules>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-bytecode-version</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <enforceBytecodeVersion>
-                  <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
-                </enforceBytecodeVersion>
-              </rules>
-              <fail>true</fail>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- reuse javaVersion property from parent
- property maven.compiler.release is set by parent for JDK 11+
- reuse checking of bytecode version from parent