### PR TITLE
Restore AbstractCompiler#getLogger() method

### DIFF
--- a/plexus-compiler-api/pom.xml
+++ b/plexus-compiler-api/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
@@ -39,7 +39,10 @@ import org.slf4j.LoggerFactory;
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
 public abstract class AbstractCompiler implements Compiler {
-    protected Logger log = LoggerFactory.getLogger(getClass());
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final org.codehaus.plexus.logging.Logger plexusLogger;
+
     protected static final String EOL = System.lineSeparator();
 
     protected static final String PS = System.getProperty("path.separator");
@@ -68,6 +71,25 @@ public abstract class AbstractCompiler implements Compiler {
         this.outputFileEnding = outputFileEnding;
 
         this.outputFile = outputFile;
+
+        this.plexusLogger = new PlexusLoggerWrapper(log);
+    }
+
+    /**
+     *
+     * @return a Logger
+     */
+    protected Logger getLog() {
+        return log;
+    }
+
+    /**
+     * @return a plexus Logger
+     * @deprecated please use {@link #getLog()}
+     */
+    @Deprecated
+    protected org.codehaus.plexus.logging.Logger getLogger() {
+        return plexusLogger;
     }
 
     // ----------------------------------------------------------------------

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/PlexusLoggerWrapper.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/PlexusLoggerWrapper.java
@@ -1,0 +1,107 @@
+package org.codehaus.plexus.compiler;
+
+import org.slf4j.Logger;
+
+class PlexusLoggerWrapper implements org.codehaus.plexus.logging.Logger {
+
+    private final Logger log;
+
+    PlexusLoggerWrapper(Logger log) {
+        this.log = log;
+    }
+
+    @Override
+    public void debug(String message) {
+        log.debug(message);
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        log.debug(message, throwable);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public void info(String message) {
+        log.info(message);
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        log.info(message, throwable);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return log.isInfoEnabled();
+    }
+
+    @Override
+    public void warn(String message) {
+        log.warn(message);
+    }
+
+    @Override
+    public void warn(String message, Throwable throwable) {
+        log.warn(message, throwable);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return log.isWarnEnabled();
+    }
+
+    @Override
+    public void error(String message) {
+        log.error(message);
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        log.error(message, throwable);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+    @Override
+    public void fatalError(String message) {
+        log.error(message);
+    }
+
+    @Override
+    public void fatalError(String message, Throwable throwable) {
+        log.error(message, throwable);
+    }
+
+    @Override
+    public boolean isFatalErrorEnabled() {
+        return log.isErrorEnabled();
+    }
+
+    @Override
+    public int getThreshold() {
+        return 0;
+    }
+
+    @Override
+    public void setThreshold(int threshold) {
+        // not implemented
+    }
+
+    @Override
+    public org.codehaus.plexus.logging.Logger getChildLogger(String name) {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return log.getName();
+    }
+}

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -229,12 +229,12 @@ public class EclipseJavaCompiler extends AbstractCompiler {
             JavaCompiler compiler = getEcj();
             boolean success = false;
             if (compiler != null) {
-                log.debug("Using JSR-199 EclipseCompiler");
+                getLog().debug("Using JSR-199 EclipseCompiler");
                 // ECJ JSR-199 compiles against the latest Java version it supports if no source
                 // version is given explicitly. BatchCompiler uses 1.3 as default. So check
                 // whether a source version is specified, and if not supply 1.3 explicitly.
                 if (!haveSourceOrReleaseArgument(args)) {
-                    log.debug("ecj: no source level nor release specified, defaulting to Java 1.3");
+                    getLog().debug("ecj: no source level nor release specified, defaulting to Java 1.3");
                     args.add("-source");
                     args.add("1.3");
                 }
@@ -286,17 +286,17 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                     try {
                         charset = Charset.forName(encoding);
                     } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
-                        log.warn("ecj: invalid or unsupported character set '" + encoding + "', using default");
+                        getLog().warn("ecj: invalid or unsupported character set '" + encoding + "', using default");
                         // charset remains null
                     }
                 }
                 if (charset == null) {
                     charset = Charset.defaultCharset();
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("ecj: using character set " + charset.displayName());
-                    log.debug("ecj command line: " + args);
-                    log.debug("ecj input source files: " + allSources);
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug("ecj: using character set " + charset.displayName());
+                    getLog().debug("ecj command line: " + args);
+                    getLog().debug("ecj input source files: " + allSources);
                 }
 
                 try (StandardJavaFileManager manager =
@@ -308,19 +308,19 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                 } catch (RuntimeException e) {
                     throw new EcjFailureException(e.getLocalizedMessage());
                 }
-                log.debug(sw.toString());
+                getLog().debug(sw.toString());
             } else {
                 // Use the BatchCompiler and send all errors to xml temp file.
                 File errorF = null;
                 try {
                     errorF = File.createTempFile("ecjerr-", ".xml");
-                    log.debug("Using legacy BatchCompiler; error file " + errorF);
+                    getLog().debug("Using legacy BatchCompiler; error file " + errorF);
 
                     args.add("-log");
                     args.add(errorF.toString());
                     args.addAll(allSources);
 
-                    log.debug("ecj command line: " + args);
+                    getLog().debug("ecj command line: " + args);
 
                     success = BatchCompiler.compile(
                             args.toArray(new String[args.size()]), devNull, devNull, new CompilationProgress() {
@@ -341,7 +341,7 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                                 @Override
                                 public void worked(int i, int i1) {}
                             });
-                    log.debug(sw.toString());
+                    getLog().debug(sw.toString());
 
                     if (errorF.length() < 80) {
                         throw new EcjFailureException(sw.toString());
@@ -524,7 +524,7 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                 }
             }
         }
-        log.debug("Cannot find org.eclipse.jdt.internal.compiler.tool.EclipseCompiler");
+        getLog().debug("Cannot find org.eclipse.jdt.internal.compiler.tool.EclipseCompiler");
         return null;
     }
 
@@ -618,7 +618,7 @@ public class EclipseJavaCompiler extends AbstractCompiler {
         }
 
         if (versionSpec.equals("1.9")) {
-            log.warn("Version 9 should be specified as 9, not 1.9");
+            getLog().warn("Version 9 should be specified as 9, not 1.9");
             return "9";
         }
         return versionSpec;

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -154,8 +154,8 @@ public class JavacCompiler extends AbstractCompiler {
                 try {
                     executable = getJavacExecutable();
                 } catch (IOException e) {
-                    if (log.isWarnEnabled()) {
-                        log.warn("Unable to autodetect 'javac' path, using 'javac' from the environment.");
+                    if (getLog().isWarnEnabled()) {
+                        getLog().warn("Unable to autodetect 'javac' path, using 'javac' from the environment.");
                     }
                     executable = "javac";
                 }
@@ -541,7 +541,7 @@ public class JavacCompiler extends AbstractCompiler {
 
         List<CompilerMessage> messages;
 
-        if (log.isDebugEnabled()) {
+        if (getLog().isDebugEnabled()) {
             String debugFileName = StringUtils.isEmpty(config.getDebugFileName()) ? "javac" : config.getDebugFileName();
 
             File commandLineFile = new File(
@@ -555,8 +555,8 @@ public class JavacCompiler extends AbstractCompiler {
                     Runtime.getRuntime().exec(new String[] {"chmod", "a+x", commandLineFile.getAbsolutePath()});
                 }
             } catch (IOException e) {
-                if (log.isWarnEnabled()) {
-                    log.warn("Unable to write '" + commandLineFile.getName() + "' debug script file", e);
+                if (getLog().isWarnEnabled()) {
+                    getLog().warn("Unable to write '" + commandLineFile.getName() + "' debug script file", e);
                 }
             }
         }
@@ -587,8 +587,8 @@ public class JavacCompiler extends AbstractCompiler {
         final Thread thread = Thread.currentThread();
         final ClassLoader contextClassLoader = thread.getContextClassLoader();
         thread.setContextClassLoader(javacClass.getClassLoader());
-        if (log.isDebugEnabled()) {
-            log.debug("ttcl changed run compileInProcessWithProperClassloader");
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("ttcl changed run compileInProcessWithProperClassloader");
         }
         try {
             return compileInProcessWithProperClassloader(javacClass, args);
@@ -880,7 +880,7 @@ public class JavacCompiler extends AbstractCompiler {
         PrintWriter writer = null;
         try {
             File tempFile;
-            if (log.isDebugEnabled()) {
+            if (getLog().isDebugEnabled()) {
                 tempFile = File.createTempFile(JavacCompiler.class.getName(), "arguments", new File(outputDirectory));
             } else {
                 tempFile = File.createTempFile(JavacCompiler.class.getName(), "arguments");


### PR DESCRIPTION
We need preserve a compatibility for some time.

API was braked in 2ed77f57ef2b5195e743db464975e8ba46531369