### PR TITLE
Report "Error occurred during initialization of VM" as error

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -638,6 +638,10 @@ public class JavacCompiler extends AbstractCompiler {
     private static final Pattern STACK_TRACE_OTHER_LINE =
             Pattern.compile("^(?:Caused by:\\s.*|\\s*at .*|\\s*\\.\\.\\.\\s\\d+\\smore)$");
 
+    // Match generic javac errors with 'javac:' prefix, JMV init and boot layer init errors
+    private static final Pattern JAVAC_OR_JVM_ERROR =
+            Pattern.compile("^(?:javac:|Error occurred during initialization of (?:boot layer|VM)).*", Pattern.DOTALL);
+
     /**
      * Parse the output from the compiler into a list of CompilerMessage objects
      *
@@ -664,10 +668,8 @@ public class JavacCompiler extends AbstractCompiler {
                 // maybe better to ignore only the summary and mark the rest as error
                 String bufferAsString = buffer.toString();
                 if (buffer.length() > 0) {
-                    if (bufferAsString.startsWith("javac:")) {
+                    if (JAVAC_OR_JVM_ERROR.matcher(bufferAsString).matches()) {
                         errors.add(new CompilerMessage(bufferAsString, CompilerMessage.Kind.ERROR));
-                    } else if (bufferAsString.startsWith("Error occurred during initialization of boot layer")) {
-                        errors.add(new CompilerMessage(bufferAsString, CompilerMessage.Kind.OTHER));
                     } else if (hasPointer) {
                         // A compiler message remains in buffer at end of parse stream
                         errors.add(parseModernError(exitCode, bufferAsString));

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -1010,7 +1010,7 @@ public class ErrorMessageParserTest {
     }
 
     @Test
-    public void testJvmError() throws Exception {
+    public void testJvmBootLayerInitializationError() throws Exception {
         String out = "Error occurred during initialization of boot layer" + EOL
                 + "java.lang.module.FindException: Module java.xml.bind not found";
 
@@ -1018,8 +1018,21 @@ public class ErrorMessageParserTest {
                 JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(out)));
 
         assertThat(compilerErrors, notNullValue());
-
         assertThat(compilerErrors.size(), is(1));
+        assertThat(compilerErrors.get(0).getKind(), is(CompilerMessage.Kind.ERROR));
+    }
+
+    @Test
+    public void testJvmInitializationError() throws Exception {
+        String out = "Error occurred during initialization of VM" + EOL
+                + "Initial heap size set to a larger value than the maximum heap size";
+
+        List<CompilerMessage> compilerErrors =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(out)));
+
+        assertThat(compilerErrors, notNullValue());
+        assertThat(compilerErrors.size(), is(1));
+        assertThat(compilerErrors.get(0).getKind(), is(CompilerMessage.Kind.ERROR));
     }
 
     @Test


### PR DESCRIPTION
Until now, this error message was just swallowed silently.

Along the way, also report "Error occurred during initialization of boot
layer" as ERROR, because probably OTHER was never the right category to
begin with. With OTHER, Maven Compiler logs both error messages on INFO,
which I believe to be wrong. Now, Maven Compiler
logs them on ERROR with "COMPILATION ERROR" header, which fits the
behaviour that the build fails. Besides, javadoc for
CompilerMessage.Kind.ERROR says "Problem which prevents the tool's
normal completion", which also is a good description of what is actually
happening for both the boot layer and VM init errors.
