### PR TITLE
Fix ECJ not using annotation processor when defined via processorpath

### DIFF
--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/invoker.properties
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.maven.version = 3.9.6+
+
+invoker.goals = clean compile
+invoker.buildResult = success

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/pom.xml
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/pom.xml
@@ -24,7 +24,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.codehaus.plexus.compiler.it</groupId>
-  <artifactId>eclipse-compiler-mapstruct</artifactId>
+  <artifactId>eclipse-compiler-procpath</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <properties>
@@ -52,6 +52,13 @@
         <version>@maven.compiler.version@</version>
         <configuration>
           <compilerId>eclipse</compilerId>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${org.mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
         <dependencies>
           <dependency>
@@ -64,33 +71,9 @@
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>
-          <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
-            <version>${org.mapstruct.version}</version>
-          </dependency>
         </dependencies>
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>without-dummy</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/Dummy.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/Car.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/Car.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Car
+{
+    public String make;
+    public int numberOfSeats;
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/CarDto.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/CarDto.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class CarDto
+{
+    public String make;
+    public int seatCount;
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/CarMapper.java
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/src/main/java/CarMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CarMapper
+{
+
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+
+    @Mapping( source = "numberOfSeats", target = "seatCount" )
+    CarDto carToCarDto( Car car );
+}

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/verify.groovy
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def mapperImplClass = new File( basedir, "target/classes/CarMapperImpl.class" )
+assert mapperImplClass.exists()
+

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -147,7 +147,21 @@ public class EclipseJavaCompiler extends AbstractCompiler {
         args.add("-d");
         args.add(config.getOutputLocation());
 
+        // -- classpath
+        // must be done before annotation processors: https://bugs.eclipse.org/bugs/show_bug.cgi?id=573833
+        List<String> classpathEntries = new ArrayList<>(config.getClasspathEntries());
+        classpathEntries.add(config.getOutputLocation());
+        args.add("-classpath");
+        args.add(getPathString(classpathEntries));
+
+        List<String> modulepathEntries = config.getModulepathEntries();
+        if (modulepathEntries != null && !modulepathEntries.isEmpty()) {
+            args.add("--module-path");
+            args.add(getPathString(modulepathEntries));
+        }
+
         // Annotation processors defined?
+        // must be done after classpath: https://bugs.eclipse.org/bugs/show_bug.cgi?id=573833
         if (!isPreJava1_6(config)) {
             File generatedSourcesDir = config.getGeneratedSourcesDirectory();
             if (generatedSourcesDir != null) {
@@ -196,18 +210,6 @@ public class EclipseJavaCompiler extends AbstractCompiler {
                     args.add("-proc:" + config.getProc());
                 }
             }
-        }
-
-        // -- classpath
-        List<String> classpathEntries = new ArrayList<>(config.getClasspathEntries());
-        classpathEntries.add(config.getOutputLocation());
-        args.add("-classpath");
-        args.add(getPathString(classpathEntries));
-
-        List<String> modulepathEntries = config.getModulepathEntries();
-        if (modulepathEntries != null && !modulepathEntries.isEmpty()) {
-            args.add("--module-path");
-            args.add(getPathString(modulepathEntries));
         }
 
         // Collect sources


### PR DESCRIPTION
Works around https://bugs.eclipse.org/bugs/show_bug.cgi?id=573833 by adding -classpath to the command line before -processorpath is added.

Fixes #349

---

The new IT failed before the reordering.

PS: As a template for the IT I used `eclipse-compiler-mapstruct` (which I added over a year ago). I took the liberty to fix in that older IT two c&p mistakes and bump the mapstruct version.