### PR TITLE
Correctly determine the version of the underlying javac tool

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -501,7 +501,7 @@ public class CompilerConfiguration {
     }
 
     /**
-     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version 
+     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version
      * of the actually executed compiler binary
      */
     @Deprecated
@@ -510,7 +510,7 @@ public class CompilerConfiguration {
     }
 
     /**
-     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version 
+     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version
      * of the actually executed compiler binary
      */
     @Deprecated

--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/CompilerConfiguration.java
@@ -500,10 +500,20 @@ public class CompilerConfiguration {
         this.optimize = optimize;
     }
 
+    /**
+     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version 
+     * of the actually executed compiler binary
+     */
+    @Deprecated
     public String getCompilerVersion() {
         return compilerVersion;
     }
 
+    /**
+     * @deprecated Don't use any longer because this is just the configured version which does not necessarily match the version 
+     * of the actually executed compiler binary
+     */
+    @Deprecated
     public void setCompilerVersion(String compilerVersion) {
         this.compilerVersion = compilerVersion;
     }

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-settings</artifactId>
+      <artifactId>maven-settings-builder</artifactId>
       <version>${mavenVersion}</version>
     </dependency>
     <dependency>

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -41,11 +41,13 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.DefaultArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.properties.internal.SystemProperties;
 import org.apache.maven.settings.Settings;
-import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +85,13 @@ public abstract class AbstractCompilerTest {
         if (localRepo == null) {
             File settingsFile = new File(System.getProperty("user.home"), ".m2/settings.xml");
             if (settingsFile.exists()) {
-                Settings settings = new SettingsXpp3Reader().read(ReaderFactory.newXmlReader(settingsFile));
+                SettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+                request.setUserSettingsFile(settingsFile);
+                request.setSystemProperties(SystemProperties.getSystemProperties());
+                Settings settings = new DefaultSettingsBuilderFactory()
+                        .newInstance()
+                        .build(request)
+                        .getEffectiveSettings();
                 localRepo = settings.getLocalRepository();
             }
         }
@@ -116,7 +124,7 @@ public abstract class AbstractCompilerTest {
         File file = getLocalArtifactPath("commons-lang", "commons-lang", "2.0", "jar");
 
         assertThat(
-                "test prerequisite: commons-lang library must be available in local repository, expected ",
+                "test prerequisite: commons-lang library must be available in local repository at " + file,
                 file,
                 FileMatchers.aReadableFile());
 

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -59,12 +59,15 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.codehaus.plexus.compiler.AbstractCompiler;
@@ -108,6 +111,8 @@ public class JavacCompiler extends AbstractCompiler {
 
     private final Deque<Class<?>> javacClasses = new ConcurrentLinkedDeque<>();
 
+    private static final Pattern JAVA_MAJOR_AND_MINOR_VERSION_PATTERN = Pattern.compile("\\d+(\\.\\d+)?");
+
     @Inject
     private InProcessCompiler inProcessCompiler;
 
@@ -128,6 +133,39 @@ public class JavacCompiler extends AbstractCompiler {
         return "javac";
     }
 
+    private String getInProcessJavacVersion() throws CompilerException {
+        return System.getProperty("java.version");
+    }
+
+    private String getOutOfProcessJavacVersion(String executable) throws CompilerException {
+        Commandline cli = new Commandline();
+        cli.setExecutable(executable);
+        /*
+         * The option "-version" should be supported by javac since 1.6 (https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/javac.html)
+         * up to 21 (https://docs.oracle.com/en/java/javase/21/docs/specs/man/javac.html#standard-options)
+         */
+        cli.addArguments(new String[] {"-version"}); //
+        CommandLineUtils.StringStreamConsumer out = new CommandLineUtils.StringStreamConsumer();
+        try {
+            int exitCode = CommandLineUtils.executeCommandLine(cli, out, out);
+            if (exitCode != 0) {
+                throw new CompilerException("Could not retrieve version from " + executable + ". Exit code " + exitCode
+                        + ", Output: " + out.getOutput());
+            }
+        } catch (CommandLineException e) {
+            throw new CompilerException("Error while executing the external compiler " + executable, e);
+        }
+        return extractMajorAndMinorVersion(out.getOutput());
+    }
+
+    static String extractMajorAndMinorVersion(String text) {
+        Matcher matcher = JAVA_MAJOR_AND_MINOR_VERSION_PATTERN.matcher(text);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("Could not extract version from \"" + text + "\"");
+        }
+        return matcher.group();
+    }
+
     @Override
     public CompilerResult performCompile(CompilerConfiguration config) throws CompilerException {
         File destinationDir = new File(config.getOutputLocation());
@@ -144,27 +182,25 @@ public class JavacCompiler extends AbstractCompiler {
 
         logCompiling(sourceFiles, config);
 
-        String[] args = buildCompilerArguments(config, sourceFiles);
+        final String javacVersion;
+        final String executable;
+        if (config.isFork()) {
+            executable = getJavacExecutable(config);
+            javacVersion = getOutOfProcessJavacVersion(executable);
+        } else {
+            javacVersion = getInProcessJavacVersion();
+            executable = null;
+        }
+
+        String[] args = buildCompilerArguments(config, sourceFiles, javacVersion);
 
         CompilerResult result;
 
         if (config.isFork()) {
-            String executable = config.getExecutable();
-
-            if (StringUtils.isEmpty(executable)) {
-                try {
-                    executable = getJavacExecutable();
-                } catch (IOException e) {
-                    if (getLog().isWarnEnabled()) {
-                        getLog().warn("Unable to autodetect 'javac' path, using 'javac' from the environment.");
-                    }
-                    executable = "javac";
-                }
-            }
 
             result = compileOutOfProcess(config, executable, args);
         } else {
-            if (isJava16() && !config.isForceJavacCompilerUse()) {
+            if (hasJavaxToolProvider() && !config.isForceJavacCompilerUse()) {
                 // use fqcn to prevent loading of the class on 1.5 environment !
                 result = inProcessCompiler().compileInProcess(args, config, sourceFiles);
             } else {
@@ -179,7 +215,11 @@ public class JavacCompiler extends AbstractCompiler {
         return inProcessCompiler;
     }
 
-    protected static boolean isJava16() {
+    /**
+     *
+     * @return {@code true} if the current context class loader has access to {@code javax.tools.ToolProvider}
+     */
+    protected static boolean hasJavaxToolProvider() {
         try {
             Thread.currentThread().getContextClassLoader().loadClass("javax.tools.ToolProvider");
             return true;
@@ -189,10 +229,18 @@ public class JavacCompiler extends AbstractCompiler {
     }
 
     public String[] createCommandLine(CompilerConfiguration config) throws CompilerException {
-        return buildCompilerArguments(config, getSourceFiles(config));
+        final String javacVersion;
+        if (config.isFork()) {
+            String executable = getJavacExecutable(config);
+            javacVersion = getOutOfProcessJavacVersion(executable);
+        } else {
+            javacVersion = getInProcessJavacVersion();
+        }
+        return buildCompilerArguments(config, getSourceFiles(config), javacVersion);
     }
 
-    public static String[] buildCompilerArguments(CompilerConfiguration config, String[] sourceFiles) {
+    public static String[] buildCompilerArguments(
+            CompilerConfiguration config, String[] sourceFiles, String javacVersion) {
         List<String> args = new ArrayList<>();
 
         // ----------------------------------------------------------------------
@@ -231,11 +279,11 @@ public class JavacCompiler extends AbstractCompiler {
 
             args.add(getPathString(sourceLocations));
         }
-        if (!isJava16() || config.isForceJavacCompilerUse() || config.isFork()) {
+        if (!hasJavaxToolProvider() || config.isForceJavacCompilerUse() || config.isFork()) {
             args.addAll(Arrays.asList(sourceFiles));
         }
 
-        if (!isPreJava16(config)) {
+        if (JavaVersion.JAVA_1_6.isOlderOrEqualTo(javacVersion)) {
             // now add jdk 1.6 annotation processing related parameters
 
             if (config.getGeneratedSourcesDirectory() != null) {
@@ -288,7 +336,7 @@ public class JavacCompiler extends AbstractCompiler {
             args.add("-verbose");
         }
 
-        if (!isPreJava18(config) && config.isParameters()) {
+        if (JavaVersion.JAVA_1_8.isOlderOrEqualTo(javacVersion) && config.isParameters()) {
             args.add("-parameters");
         }
 
@@ -338,17 +386,17 @@ public class JavacCompiler extends AbstractCompiler {
                 args.add(config.getTargetVersion());
             }
 
-            if (!suppressSource(config) && StringUtils.isEmpty(config.getSourceVersion())) {
+            if (JavaVersion.JAVA_1_4.isOlderOrEqualTo(javacVersion) && StringUtils.isEmpty(config.getSourceVersion())) {
                 // If omitted, later JDKs complain about a 1.1 target
                 args.add("-source");
                 args.add("1.3");
-            } else if (!suppressSource(config)) {
+            } else if (JavaVersion.JAVA_1_4.isOlderOrEqualTo(javacVersion)) {
                 args.add("-source");
                 args.add(config.getSourceVersion());
             }
         }
 
-        if (!suppressEncoding(config) && !StringUtils.isEmpty(config.getSourceEncoding())) {
+        if (JavaVersion.JAVA_1_4.isOlderOrEqualTo(javacVersion) && !StringUtils.isEmpty(config.getSourceEncoding())) {
             args.add("-encoding");
             args.add(config.getSourceEncoding());
         }
@@ -384,115 +432,38 @@ public class JavacCompiler extends AbstractCompiler {
     }
 
     /**
-     * Determine if the compiler is a version prior to 1.4.
-     * This is needed as 1.3 and earlier did not support -source or -encoding parameters
-     *
-     * @param config The compiler configuration to test.
-     * @return true if the compiler configuration represents a Java 1.4 compiler or later, false otherwise
+     * Represents a particular Java version (through their according version prefixes)
      */
-    private static boolean isPreJava14(CompilerConfiguration config) {
-        String v = config.getCompilerVersion();
+    enum JavaVersion {
+        JAVA_1_3("1.3", "1.2", "1.1", "1.0"),
+        JAVA_1_4("1.4"),
+        JAVA_1_5("1.5"),
+        JAVA_1_6("1.6"),
+        JAVA_1_7("1.7"),
+        JAVA_1_8("1.8"),
+        JAVA_9("9"); // since Java 9 a different versioning scheme was used (https://openjdk.org/jeps/223)
+        final Set<String> versionPrefixes;
 
-        if (v == null) {
-            return false;
+        JavaVersion(String... versionPrefixes) {
+            this.versionPrefixes = new HashSet<>(Arrays.asList(versionPrefixes));
         }
 
-        return v.startsWith("1.3") || v.startsWith("1.2") || v.startsWith("1.1") || v.startsWith("1.0");
-    }
-
-    /**
-     * Determine if the compiler is a version prior to 1.6.
-     * This is needed for annotation processing parameters.
-     *
-     * @param config The compiler configuration to test.
-     * @return true if the compiler configuration represents a Java 1.6 compiler or later, false otherwise
-     */
-    private static boolean isPreJava16(CompilerConfiguration config) {
-        String v = config.getReleaseVersion();
-
-        if (v == null) {
-            v = config.getCompilerVersion();
-        }
-
-        if (v == null) {
-            v = config.getSourceVersion();
-        }
-
-        if (v == null) {
+        /**
+         * The internal logic checks if the given version starts with the prefix of one of the enums preceding the current one.
+         *
+         * @param version the version to check
+         * @return {@code true} if the version represented by this enum is older than or equal (in its minor and major version) to a given version
+         */
+        boolean isOlderOrEqualTo(String version) {
+            // go through all previous enums
+            JavaVersion[] allJavaVersionPrefixes = JavaVersion.values();
+            for (int n = ordinal() - 1; n > -1; n--) {
+                if (allJavaVersionPrefixes[n].versionPrefixes.stream().anyMatch(version::startsWith)) {
+                    return false;
+                }
+            }
             return true;
         }
-
-        return v.startsWith("5")
-                || v.startsWith("1.5")
-                || v.startsWith("1.4")
-                || v.startsWith("1.3")
-                || v.startsWith("1.2")
-                || v.startsWith("1.1")
-                || v.startsWith("1.0");
-    }
-
-    private static boolean isPreJava18(CompilerConfiguration config) {
-        String v = config.getReleaseVersion();
-
-        if (v == null) {
-            v = config.getCompilerVersion();
-        }
-
-        if (v == null) {
-            v = config.getSourceVersion();
-        }
-
-        if (v == null) {
-            return true;
-        }
-
-        return v.startsWith("7")
-                || v.startsWith("1.7")
-                || v.startsWith("6")
-                || v.startsWith("1.6")
-                || v.startsWith("1.5")
-                || v.startsWith("1.4")
-                || v.startsWith("1.3")
-                || v.startsWith("1.2")
-                || v.startsWith("1.1")
-                || v.startsWith("1.0");
-    }
-
-    private static boolean isPreJava9(CompilerConfiguration config) {
-
-        String v = config.getReleaseVersion();
-
-        if (v == null) {
-            v = config.getCompilerVersion();
-        }
-
-        if (v == null) {
-            v = config.getSourceVersion();
-        }
-
-        if (v == null) {
-            return true;
-        }
-
-        return v.startsWith("8")
-                || v.startsWith("1.8")
-                || v.startsWith("7")
-                || v.startsWith("1.7")
-                || v.startsWith("1.6")
-                || v.startsWith("1.5")
-                || v.startsWith("1.4")
-                || v.startsWith("1.3")
-                || v.startsWith("1.2")
-                || v.startsWith("1.1")
-                || v.startsWith("1.0");
-    }
-
-    private static boolean suppressSource(CompilerConfiguration config) {
-        return isPreJava14(config);
-    }
-
-    private static boolean suppressEncoding(CompilerConfiguration config) {
-        return isPreJava14(config);
     }
 
     /**
@@ -926,10 +897,32 @@ public class JavacCompiler extends AbstractCompiler {
     }
 
     /**
+     * Get the path of the javac tool executable to use.
+     * Either given through explicit configuration or via {@link #getJavacExecutable()}.
+     * @param config the configuration
+     * @return the path of the javac tool
+     */
+    protected String getJavacExecutable(CompilerConfiguration config) {
+        String executable = config.getExecutable();
+
+        if (StringUtils.isEmpty(executable)) {
+            try {
+                executable = getJavacExecutable();
+            } catch (IOException e) {
+                if (getLog().isWarnEnabled()) {
+                    getLog().warn("Unable to autodetect 'javac' path, using 'javac' from the environment.");
+                }
+                executable = "javac";
+            }
+        }
+        return executable;
+    }
+
+    /**
      * Get the path of the javac tool executable: try to find it depending the OS or the <code>java.home</code>
      * system property or the <code>JAVA_HOME</code> environment variable.
      *
-     * @return the path of the Javadoc tool
+     * @return the path of the javac tool
      * @throws IOException if not found
      */
     private static String getJavacExecutable() throws IOException {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -34,12 +34,10 @@ import java.util.Map;
 import org.codehaus.plexus.compiler.AbstractCompilerTest;
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.codehaus.plexus.util.StringUtils;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
@@ -207,22 +205,19 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
                 "org/codehaus/foo/ReservedWord.class");
     }
 
-    protected void internalTest(CompilerConfiguration compilerConfiguration, List<String> expectedArguments) {
-        internalTest(compilerConfiguration, expectedArguments, new String[0]);
+    protected void internalTest(
+            CompilerConfiguration compilerConfiguration, List<String> expectedArguments, String javacVersion) {
+        internalTest(compilerConfiguration, expectedArguments, new String[0], javacVersion);
     }
 
     public void internalTest(
-            CompilerConfiguration compilerConfiguration, List<String> expectedArguments, String[] sources) {
-        String[] actualArguments = JavacCompiler.buildCompilerArguments(compilerConfiguration, sources);
+            CompilerConfiguration compilerConfiguration,
+            List<String> expectedArguments,
+            String[] sources,
+            String javacVersion) {
+        String[] actualArguments = JavacCompiler.buildCompilerArguments(compilerConfiguration, sources, javacVersion);
 
-        assertThat(
-                "The expected and actual argument list sizes differ.",
-                actualArguments,
-                Matchers.arrayWithSize(expectedArguments.size()));
-
-        for (int i = 0; i < actualArguments.length; i++) {
-            assertThat("Unexpected argument", actualArguments[i], is(expectedArguments.get(i)));
-        }
+        assertArrayEquals(actualArguments, expectedArguments.toArray(new String[0]));
     }
 
     @Test
@@ -231,11 +226,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        compilerConfiguration.setCompilerVersion("1.3");
-
         populateArguments(compilerConfiguration, expectedArguments, true, true, false);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.3");
     }
 
     @Test
@@ -244,11 +237,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        compilerConfiguration.setCompilerVersion("1.4");
-
         populateArguments(compilerConfiguration, expectedArguments, false, false, false);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.4");
     }
 
     @Test
@@ -257,11 +248,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        compilerConfiguration.setCompilerVersion("1.5");
-
         populateArguments(compilerConfiguration, expectedArguments, false, false, false);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.5");
     }
 
     @Test
@@ -270,11 +259,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        compilerConfiguration.setCompilerVersion("1.8");
-
         populateArguments(compilerConfiguration, expectedArguments, false, false, true);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.8");
     }
 
     @Test
@@ -283,9 +270,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
 
-        populateArguments(compilerConfiguration, expectedArguments, false, false, false);
+        populateArguments(compilerConfiguration, expectedArguments, false, false, true);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "unknown");
     }
 
     @Test
@@ -298,9 +285,9 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
 
         compilerConfiguration.setDebugLevel("none");
 
-        populateArguments(compilerConfiguration, expectedArguments, false, false, false);
+        populateArguments(compilerConfiguration, expectedArguments, false, false, true);
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.8");
     }
 
     // PLXCOMP-190
@@ -334,7 +321,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         compilerConfiguration.setCustomCompilerArgumentsAsMap(customCompilerArguments);
         // don't expect this argument!!
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.8");
     }
 
     @Test
@@ -370,7 +357,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments, source);
+        internalTest(compilerConfiguration, expectedArguments, source, "11.0.1");
     }
 
     @Test
@@ -399,7 +386,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "11.0.1");
     }
 
     @Test
@@ -427,7 +414,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "11.0.1");
     }
 
     @Test
@@ -449,7 +436,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "11.0.1");
     }
 
     @Test
@@ -476,7 +463,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.8");
     }
 
     @Test
@@ -507,7 +494,7 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         // unshared table
         expectedArguments.add("-XDuseUnsharedTable=true");
 
-        internalTest(compilerConfiguration, expectedArguments);
+        internalTest(compilerConfiguration, expectedArguments, "1.8");
     }
 
     /* This test fails on Java 1.4. The multiple parameters of the same source file cause an error, as it is interpreted as a DuplicateClass

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavacCompilerTest.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.codehaus.plexus.compiler.CompilerMessage;
+import org.codehaus.plexus.compiler.javac.JavacCompiler.JavaVersion;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,6 +20,9 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -102,5 +107,23 @@ public class JavacCompilerTest extends AbstractJavacCompilerTest {
                 Arguments.of(
                         "JDK 21 German",
                         "\n\nEin Annotationsprozessor hat eine nicht abgefangene Ausnahme ausgelöst.\nDetails finden Sie im folgenden Stacktrace.\n\n"));
+    }
+
+    @Test
+    void testJavaVersionPrefixes() {
+        assertFalse(JavaVersion.JAVA_1_4.isOlderOrEqualTo("1.3"));
+        assertTrue(JavaVersion.JAVA_1_4.isOlderOrEqualTo("1.4"));
+        assertTrue(JavaVersion.JAVA_1_4.isOlderOrEqualTo("1.4.0_something"));
+        assertFalse(JavaVersion.JAVA_1_5.isOlderOrEqualTo("1.4"));
+        assertTrue(JavaVersion.JAVA_1_8.isOlderOrEqualTo("1.8"));
+        assertTrue(JavaVersion.JAVA_1_8.isOlderOrEqualTo("22.0.2-something"));
+        assertTrue(JavaVersion.JAVA_1_8.isOlderOrEqualTo("unknown"));
+    }
+
+    @Test
+    void testExtractMajorAndMinorVersion() {
+        assertEquals("11.0", JavacCompiler.extractMajorAndMinorVersion("javac 11.0.22"));
+        assertEquals("11.0", JavacCompiler.extractMajorAndMinorVersion("11.0.22"));
+        assertEquals("21", JavacCompiler.extractMajorAndMinorVersion("javac 21"));
     }
 }

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -36,6 +36,13 @@
       <artifactId>plexus-compiler-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- this is used for populating a test classpath in AbstractCompiler and is required in the local repository -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Ignore CompilerConfiguration values as they are unreliable (and don't represent the used javac version)
Make test execution more resilient by interpolating settings.xml correctly and make sure commons-lang 2.0 is resolved prior to unit testing

This closes #356