### PR TITLE
Make Eclipse and AspectJ compilers run on JDK 11 again

### DIFF
--- a/plexus-compilers/plexus-compiler-aspectj/pom.xml
+++ b/plexus-compilers/plexus-compiler-aspectj/pom.xml
@@ -14,7 +14,7 @@
   <description>AspectJ Compiler support for Plexus Compiler component.</description>
 
   <properties>
-    <javaVersion>17</javaVersion>
+    <javaVersion>11</javaVersion>
   </properties>
 
   <dependencies>

--- a/plexus-compilers/plexus-compiler-eclipse/pom.xml
+++ b/plexus-compilers/plexus-compiler-eclipse/pom.xml
@@ -14,7 +14,7 @@
   <description>Eclipse Compiler support for Plexus Compiler component.</description>
 
   <properties>
-    <javaVersion>17</javaVersion>
+    <javaVersion>11</javaVersion>
   </properties>
 
   <dependencies>
@@ -56,5 +56,36 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <excludes>
+                <exclude>**/EclipseJavaCompilerDelegate.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java-17</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>17</release>
+              <includes>
+                <include>**/EclipseJavaCompilerDelegate.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerDelegate.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompilerDelegate.java
@@ -1,0 +1,44 @@
+package org.codehaus.plexus.compiler.eclipse;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import org.eclipse.jdt.core.compiler.CompilationProgress;
+import org.eclipse.jdt.core.compiler.batch.BatchCompiler;
+
+/**
+ * Wraps API calls involving Java 17 class files from ECJ. {@link EclipseJavaCompiler} delegates to this class.
+ * <p>
+ * <b>Note:</b> This class needs to be compiled with target 17, while all the other classes in this module can be
+ * compiled with target 11, as long as they do not directly import this class but use {@link Class#forName(String)} and
+ * method handles to invoke any methods from here.
+ */
+public class EclipseJavaCompilerDelegate {
+    static ClassLoader getClassLoader() {
+        return BatchCompiler.class.getClassLoader();
+    }
+
+    static boolean batchCompile(List<String> args, PrintWriter devNull) {
+        return BatchCompiler.compile(
+                args.toArray(new String[0]), devNull, devNull, new BatchCompilerCompilationProgress());
+    }
+
+    private static class BatchCompilerCompilationProgress extends CompilationProgress {
+        @Override
+        public void begin(int i) {}
+
+        @Override
+        public void done() {}
+
+        @Override
+        public boolean isCanceled() {
+            return false;
+        }
+
+        @Override
+        public void setTaskName(String s) {}
+
+        @Override
+        public void worked(int i, int i1) {}
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-java</id>
+            <id>enforce-maven-and-java-bytecode</id>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -192,6 +192,15 @@
                   <version>[17,)</version>
                   <message>[ERROR] OLD JDK [${java.version}] in use. This projects requires JDK 17 or newer</message>
                 </requireJavaVersion>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>11</maxJdkVersion>
+                  <excludes>
+                    <!-- Java 17 -->
+                    <exclude>org.aspectj:aspectjtools</exclude>
+                    <exclude>org.eclipse.jdt:ecj</exclude>
+                    <exclude>org.codehaus.plexus:plexus-compiler-eclipse</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
AspectJ can compile many projects on JDK 11, because it is not always using Java 17 classes from JDT Core. If it does not work, there will be a runtime error, and the user can figure out what is wrong.

For ECJ, the case is more complicated, because it directly imports Java 17 classes from JDT Core. There were isolated in new class `EclipseJavaCompilerDelegate`, which is accessed using `Class::forName` and method handles from `EclipseJavaCompiler`.

I.e., Sisu Inject can scan the annotations on `EclipseJavaCompiler` on JDK 11, and there is no more confusing "No such compiler 'eclipse'" error, but rather:

```text
Error injecting constructor, ... EcjFailureException:
Failed to run the ecj compiler: ECJ only works on Java 17+
  at org.codehaus.plexus.compiler.eclipse.EclipseJavaCompiler.<init>
```

This explicitly tells the user what is wrong.

A multi-release JAR solution was tested and worked well in Maven, but was dismissed due to the terrible developer experience in IDEs.

Fixes #347.