### PR TITLE
Lazy providers and better error reporting

### DIFF
--- a/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/pom.xml
+++ b/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/pom.xml
@@ -66,6 +66,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/aspectj-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/pom.xml
@@ -50,6 +50,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-aspectj</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/pom.xml
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-mapstruct/pom.xml
@@ -61,6 +61,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/pom.xml
+++ b/plexus-compiler-its/src/main/it/eclipse-compiler-procpath/pom.xml
@@ -68,6 +68,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml
@@ -85,6 +85,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac-errorprone</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/missing-warnings/pom.xml
+++ b/plexus-compiler-its/src/main/it/missing-warnings/pom.xml
@@ -27,6 +27,11 @@
 						</dependency>
 						<dependency>
 							<groupId>org.codehaus.plexus</groupId>
+							<artifactId>plexus-compiler-manager</artifactId>
+							<version>${plexus.compiler.version}</version>
+						</dependency>
+						<dependency>
+							<groupId>org.codehaus.plexus</groupId>
 							<artifactId>plexus-compiler-javac</artifactId>
 							<version>${plexus.compiler.version}</version>
 						</dependency>

--- a/plexus-compiler-its/src/main/it/simple-eclipse-compiler-fail/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-eclipse-compiler-fail/pom.xml
@@ -63,6 +63,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/simple-eclipse-compiler/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-eclipse-compiler/pom.xml
@@ -63,6 +63,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/simple-javac-fork/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-javac-fork/pom.xml
@@ -65,6 +65,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-its/src/main/it/simple-javac/pom.xml
+++ b/plexus-compiler-its/src/main/it/simple-javac/pom.xml
@@ -65,6 +65,11 @@
           </dependency>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-manager</artifactId>
+            <version>${plexus.compiler.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac</artifactId>
             <version>${plexus.compiler.version}</version>
           </dependency>

--- a/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/DefaultCompilerManager.java
+++ b/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/DefaultCompilerManager.java
@@ -69,7 +69,7 @@ public class DefaultCompilerManager implements CompilerManager {
         } catch (Exception e) {
             // DI could not construct compiler
             log.error(ERROR_MESSAGE, compilerId);
-            throw new NoSuchCompilerException(compilerId);
+            throw new NoSuchCompilerException(compilerId, e);
         }
     }
 }

--- a/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/DefaultCompilerManager.java
+++ b/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/DefaultCompilerManager.java
@@ -39,7 +39,8 @@ import org.slf4j.LoggerFactory;
 @Named
 public class DefaultCompilerManager implements CompilerManager {
     private static final String ERROR_MESSAGE = "Compiler '{}' could not be instantiated or injected properly. "
-            + "Running the build with -Dsisu.debug, looking for exceptions might help.";
+            + "If you spelled the compiler ID correctly and all necessary dependencies are on the classpath, "
+            + "then next you can try running the build with -Dsisu.debug, looking for exceptions.";
     private static final String ERROR_MESSAGE_DETAIL = "TypeNotPresentException caused by UnsupportedClassVersionError "
             + "might indicate, that the compiler needs a more recent Java runtime. "
             + "IllegalArgumentException in ClassReader.<init> might mean, that you need to upgrade Maven.";

--- a/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/NoSuchCompilerException.java
+++ b/plexus-compiler-manager/src/main/java/org/codehaus/plexus/compiler/manager/NoSuchCompilerException.java
@@ -31,8 +31,11 @@ public class NoSuchCompilerException extends Exception {
     private final String compilerId;
 
     public NoSuchCompilerException(String compilerId) {
-        super("No such compiler '" + compilerId + "'.");
+        this(compilerId, null);
+    }
 
+    public NoSuchCompilerException(String compilerId, Throwable cause) {
+        super("No such compiler '" + compilerId + "'", cause);
         this.compilerId = compilerId;
     }
 


### PR DESCRIPTION
Fixes #347. Supersedes #358, #359.

@cstamas, @laeubi.

Error messages now rather look like this:

```text
[INFO] --- maven-compiler-plugin:3.12.1:compile (default-compile) @ example ---
[ERROR] Compiler 'eclipse' either was not found (e.g. wrong compiler ID, missing dependencies) or its class could not be scanned. Running the build with -Dsisu.debug, looking for exceptions might help. TypeNotPresentException caused by UnsupportedClassVersionError might indicate, that the compiler needs a more recent Java runtime. IllegalArgumentException in ClassReader.<init> might mean, that you need to upgrade Maven.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.013 s
[INFO] Finished at: 2024-02-03T08:48:40+07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project example: No such compiler 'eclipse'. -> [Help 1]
```

I.e., we still have "No such compiler 'eclipse'", but also this error message before the build failure (added line breaks):

```text
Compiler 'eclipse' either was not found (e.g. wrong compiler ID, missing dependencies) or its class could not be scanned.
Running the build with -Dsisu.debug, looking for exceptions might help.
TypeNotPresentException caused by UnsupportedClassVersionError might indicate, that the compiler needs a more recent Java runtime.
IllegalArgumentException in ClassReader.<init> might mean, that you need to upgrade Maven.
```

This is a bit wordy, but IMO much better than nothing or too terse. An error message should not just say that and what kind of error occurred, but - if possible - also hint to the user how t get more information or point out poossible known root causes. At the end of the day, that saves support effort.