### PR TITLE
Format the converted site page to the project's spotless rules

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -26,9 +26,10 @@ It is composed by:
 - [`plexus-compiler-api`](./plexus-compiler-api/): the API to use compilers,
 - [`plexus-compiler-manager`](./plexus-compiler-manager/): a manager to choose a compiler,
 - [`plexus-compilers`](./plexus-compilers/): different compilers
-    - [`plexus-compiler-aspectj`](./plexus-compilers/plexus-compiler-aspectj/): AspectJ compiler, **requires** `JDK 17+` and `Maven 3.9.6+`
-    - [`plexus-compiler-csharp`](./plexus-compilers/plexus-compiler-csharp/): C#/Mono compiler, **requires** `JDK 8+`
-    - [`plexus-compiler-eclipse`](./plexus-compilers/plexus-compiler-eclipse/): Eclipse compiler, **requires** `JDK 17+` and `Maven 3.9.6+`
-    - [`plexus-compiler-javac`](./plexus-compilers/plexus-compiler-javac/): javac compiler, **requires** `JDK 8+`
-    - [`plexus-compiler-javac-errorprone`](./plexus-compilers/plexus-compiler-javac-errorprone/): javac compiler with [error-prone](https://errorprone.info) static analysis checks enabled, **requires** `JDK 11+`
+  - [`plexus-compiler-aspectj`](./plexus-compilers/plexus-compiler-aspectj/): AspectJ compiler, **requires** `JDK 17+` and `Maven 3.9.6+`
+  - [`plexus-compiler-csharp`](./plexus-compilers/plexus-compiler-csharp/): C#/Mono compiler, **requires** `JDK 8+`
+  - [`plexus-compiler-eclipse`](./plexus-compilers/plexus-compiler-eclipse/): Eclipse compiler, **requires** `JDK 17+` and `Maven 3.9.6+`
+  - [`plexus-compiler-javac`](./plexus-compilers/plexus-compiler-javac/): javac compiler, **requires** `JDK 8+`
+  - [`plexus-compiler-javac-errorprone`](./plexus-compilers/plexus-compiler-javac-errorprone/): javac compiler with [error-prone](https://errorprone.info) static analysis checks enabled, **requires** `JDK 11+`
 - [`plexus-compiler-test`](./plexus-compiler-test/): a test harness.
+


### PR DESCRIPTION
The APT to Markdown conversion indented paragraph continuations inside list items with four spaces; spotless wants two, so a build of `master` currently fails its own `spotless:check`.

Formatting only, produced by `mvn spotless:apply`. Verified by building the site before and after: the rendered page is unchanged.

Follow-up to #487, part of the migration tracked in https://github.com/apache/maven-doxia-converter/issues/139