### PR TITLE
Rewrite README with usage, status and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,68 @@
-Plexus-Compiler
-===============
+# Plexus Compiler
 
-[![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/codehaus-plexus/plexus-compiler.svg?label=License)](http://www.apache.org/licenses/)
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-compiler.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-compiler)
-[![CI](https://github.com/codehaus-plexus/plexus-compiler/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-compiler/actions/workflows/maven.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-compiler-api.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codehaus.plexus/plexus-compiler-api)
+[![GitHub CI](https://github.com/codehaus-plexus/plexus-compiler/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-compiler/actions/workflows/maven.yml)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/codehaus/plexus/plexus-compiler/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/plexus/plexus-compiler/README.md)
 
-This component is an Compilation API used by Apache Maven Compiler plugin on the top of different Compiler Engines: Javac, Eclipse Compiler, etc..
+One API over several Java compilers, so a build tool can switch between them without knowing how each is
+invoked. This is what `maven-compiler-plugin` uses: its `<compilerId>` selects one of the implementations
+below.
 
-### Error Prone usage
+## Modules
 
-Please refer to [documentation](https://errorprone.info/docs/installation#maven)
+|              Artifact              |                                       What it is                                        |
+|------------------------------------|-----------------------------------------------------------------------------------------|
+| `plexus-compiler-api`              | The `Compiler` interface and its configuration. Depend on this to write against the API |
+| `plexus-compiler-manager`          | Looks up an implementation by id                                                        |
+| `plexus-compiler-javac`            | The JDK compiler — the default                                                          |
+| `plexus-compiler-eclipse`          | The Eclipse batch compiler (ECJ)                                                        |
+| `plexus-compiler-javac-errorprone` | javac with [Error Prone](https://errorprone.info/)                                      |
+| `plexus-compiler-aspectj`          | AspectJ                                                                                 |
+| `plexus-compiler-csharp`           | C#                                                                                      |
 
-Or the project [it test](plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml)
+## Status
+
+Maintained. `maven-compiler-plugin` depends on this, so public API is kept compatible.
+
+## Using it
+
+To write against the API:
+
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-compiler-api</artifactId>
+  <version>2.16.2</version>
+</dependency>
+```
+
+Check the badge above for the current version.
+
+To *use* a non-default compiler in a build, you normally do not depend on these directly — you set
+`<compilerId>` on `maven-compiler-plugin` and add the matching implementation to that plugin's
+dependencies. See the
+[Maven documentation](https://maven.apache.org/plugins/maven-compiler-plugin/non-javac-compilers.html).
+
+### Error Prone
+
+See the [Error Prone installation guide](https://errorprone.info/docs/installation#maven), or the
+[integration test](plexus-compiler-its/src/main/it/error-prone-compiler/pom.xml) in this repository for a
+working example.
+
+## Requirements
+
+Java 8 or later.
+
+## Documentation
+
+- [Project site](https://codehaus-plexus.github.io/plexus-compiler/)
+- [Javadoc](https://javadoc.io/doc/org.codehaus.plexus/plexus-compiler-api)
+- [Release notes](https://github.com/codehaus-plexus/plexus-compiler/releases)
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/codehaus-plexus/.github/blob/master/CONTRIBUTING.md). In short:
+`mvn verify` builds, and run `mvn spotless:apply` before pushing or CI will fail on formatting.
+
+Please report security vulnerabilities privately — see
+[SECURITY.md](https://github.com/codehaus-plexus/.github/blob/master/SECURITY.md), not a public issue.


### PR DESCRIPTION
Part of codehaus-plexus/.github#58. Same skeleton as the merged pilots.

This repo publishes **seven artifacts** and the README listed none of them, so a reader had no way to work out which one to depend on. It now has a module table:

| Artifact | What it is |
|---|---|
| `plexus-compiler-api` | The `Compiler` interface — depend on this to write against the API |
| `plexus-compiler-manager` | Looks up an implementation by id |
| `plexus-compiler-javac` | The JDK compiler, the default |
| `plexus-compiler-eclipse` | ECJ |
| `plexus-compiler-javac-errorprone` | javac with Error Prone |
| `plexus-compiler-aspectj` | AspectJ |
| `plexus-compiler-csharp` | C# |

It also makes a distinction the old README did not: most people should **not** depend on these directly. To use a non-default compiler you set `<compilerId>` on `maven-compiler-plugin` and add the implementation to *that plugin's* dependencies. Linked to the Maven page that explains it.

The existing Error Prone pointer and the link to the integration test are kept — both still resolve.

While writing this I first linked `…/examples/non-javac-compilers.html`, which 404s; the correct URL has no `examples/` segment. Both links in the final version are checked.

Ran `mvn spotless:apply`.