### PR TITLE
Drop the managed plexus-component-annotations entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,6 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>2.2.0</version>
-      </dependency>
-      <dependency>
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>


### PR DESCRIPTION
The entry sits in `dependencyManagement` only — no module depends on `plexus-component-annotations`, and no source imports `org.codehaus.plexus.component.annotations`. The components are JSR-330, wired through `javax.inject` and sisu. So it manages a version for an artifact that never enters a dependency tree, and nothing downstream can lose it transitively.

Its repository, plexus-containers, has been archived since 2023, so 2.2.0 is terminal in any case.

Verified: `mvn dependency:tree -Dincludes=org.codehaus.plexus:plexus-component-annotations` reports no matches across the reactor, unchanged by this commit.

*This change was created with AI assistance.*