### PR TITLE
Report javac output that no classifier recognised

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -734,6 +734,11 @@ public class JavacCompiler extends AbstractCompiler {
             + ").*$");
 
     // Match exception causes, existing and omitted stack trace elements
+    /**
+     * A line that is only a tally, such as {@code 2 errors}, {@code 1 error} or the localised {@code 警告 1 個}.
+     */
+    private static final Pattern COUNT_SUMMARY = Pattern.compile("^\\s*(?:\\d+\\s+\\S+|\\S+\\s+\\d+\\s+\\S+)\\s*$");
+
     private static final Pattern STACK_TRACE_OTHER_LINE =
             Pattern.compile("^(?:Caused by:\\s.*|\\s*at .*|\\s*\\.\\.\\.\\s\\d+\\smore)$");
 
@@ -825,14 +830,33 @@ public class JavacCompiler extends AbstractCompiler {
                 buffer.append(lines[i]).append(EOL);
             }
             errors.add(new CompilerMessage(buffer.toString(), ERROR));
+        } else if (exitCode != 0) {
+            // Nothing in the buffer was recognised, yet the compiler failed. Whatever is left is reported rather
+            // than dropped, so that a failing build is never left without an explanation.
+            String unrecognised = stripCountSummaries(bufferContent);
+            if (!unrecognised.isEmpty()) {
+                errors.add(new CompilerMessage(unrecognised, ERROR));
+            }
         }
-        // TODO: Add something like this? Check if it creates more value or more unnecessary log output in general.
-        // else {
-        //     // Fall-back, if still no error or stack trace was recognised
-        //     errors.add(new CompilerMessage(bufferContent, exitCode == 0 ? OTHER : ERROR));
-        // }
 
         return errors;
+    }
+
+    /**
+     * Drops javac's trailing tallies, such as {@code 2 errors} or {@code 警告 1 個}, from otherwise unrecognised
+     * output. They repeat what the parsed messages already say, so on their own they are not worth reporting.
+     *
+     * @param content the unrecognised output
+     * @return the same content without its count lines, trimmed
+     */
+    private static String stripCountSummaries(String content) {
+        StringBuilder kept = new StringBuilder();
+        for (String line : content.split("\\R")) {
+            if (!line.trim().isEmpty() && !COUNT_SUMMARY.matcher(line).matches()) {
+                kept.append(line).append(EOL);
+            }
+        }
+        return kept.toString().trim();
     }
 
     private static boolean isMisc(String message) {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -1262,6 +1262,60 @@ public class ErrorMessageParserTest {
         validateBadSourceFile(secondMessage);
     }
 
+    @Test
+    public void testUnrecognisedOutputIsReportedWhenCompilationFails() throws IOException {
+        String output = "some diagnostic nobody taught this parser about" + EOL + "and a second line of it" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(output)));
+
+        assertEquals(1, messages.size());
+        assertEquals(CompilerMessage.Kind.ERROR, messages.get(0).getKind());
+        assertTrue(messages.get(0).getMessage().contains("nobody taught this parser about"));
+        assertTrue(messages.get(0).getMessage().contains("second line"));
+    }
+
+    @Test
+    public void testUnrecognisedOutputIsIgnoredWhenCompilationSucceeds() throws IOException {
+        String output = "some diagnostic nobody taught this parser about" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    public void testCountSummaryAloneIsNotReported() throws IOException {
+        String output = "2 errors" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(output)));
+
+        assertTrue(messages.isEmpty());
+    }
+
+    /**
+     * Warnings promoted by {@code -Werror} carry the file name inline rather than as a prefix, so none of the
+     * classifiers match them and they used to be dropped, leaving the failure unexplained.
+     */
+    @Test
+    public void testWerrorWarningsAreReported() throws IOException {
+        String output =
+                "gson-2.10.2-SNAPSHOT.jar(/com/google/gson/JsonParser.class): warning: Cannot find annotation method 'replacement()' in type 'InlineMe'"
+                        + EOL + "error: warnings found and -Werror specified"
+                        + EOL + "1 error"
+                        + EOL + "1 warning"
+                        + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(output)));
+
+        assertTrue(
+                messages.stream().anyMatch(m -> m.getMessage().contains("Cannot find annotation method")),
+                "the unclassified warning should survive: " + messages);
+    }
+
     private void validateBadSourceFile(CompilerMessage message) {
         assertEquals(CompilerMessage.Kind.ERROR, message.getKind(), "Is an Error");
         assertEquals("/MTOOLCHAINS-19/src/main/java/ch/pecunifex/x/Cls1.java", message.getFile(), "On Correct File");


### PR DESCRIPTION
Closes #66.

A failing compile whose output matched none of the classifiers came back with an empty message list, so the build failed and said nothing about why. #66 reached that through a javac `StackOverflowError`; the same thread has it through `-Werror` warnings that carry the file name inline rather than as a prefix, and #307 reads the same way.

The remaining buffer is now reported as an error, but only when javac actually failed — successful builds stay as quiet as they are today. Javac's trailing tallies (`2 errors`, `1 warning`, and the localised forms) are dropped first, since they only repeat what the parsed messages already say; without that, every failing compile would gain a message.

Stack traces were already handled by #337, so the other half of #66 is covered.

Verified: reverting `JavacCompiler` fails the two new reporting tests and leaves the two quietness tests passing; whole module 111 tests green.

*This change was created with AI assistance.*
