### PR TITLE
Drop two properties the build does not need

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,8 @@
     <project.build.outputTimestamp>2026-01-25T22:48:03Z</project.build.outputTimestamp>
     <aspectj.version>1.9.21</aspectj.version>
     <mavenVersion>3.8.1</mavenVersion>
-    <minimalMavenBuildVersion>${mavenVersion}</minimalMavenBuildVersion>
     <errorprone.version>2.37.0</errorprone.version>
     <eclipse.sisu.version>1.1.0</eclipse.sisu.version>
-    <sisuMavenPluginVersion>${eclipse.sisu.version}</sisuMavenPluginVersion>
     <trimStackTrace>false</trimStackTrace>
     <preparationGoals>clean install</preparationGoals>
     <maven.compiler.version>3.15.0</maven.compiler.version>


### PR DESCRIPTION
`sisuMavenPluginVersion` was declared and never read — lines 114 and 119, the two places that version sisu artifacts, use `eclipse.sisu.version` directly. It would have gone stale silently.

`minimalMavenBuildVersion` held the build floor at `mavenVersion`, 3.8.1. Inheriting it puts this project on the same floor as the rest of the org: 3.6.3 today, 3.9.0 once plexus-pom 27 lands. `mavenVersion` itself stays — it versions the `maven-artifact` and `maven-core` dependencies in plexus-compiler-test, which is a different thing from the Maven needed to *run* the build. One property was serving both roles.

`maven.compiler.version` looks equally redundant, since the parent manages that plugin at the same 3.15.0, but it is deliberately kept: plexus-compiler-its interpolates `@maven.compiler.version@` into eight standalone IT projects that do not inherit the parent. Dropping it fails the ITs with `maven-compiler-plugin:@maven.compiler.version@` — I tried. Once this project is on 27 it can be defined as `${version.maven-compiler-plugin}` so the two cannot drift.

Verified: `mvn clean verify` green across the reactor, working tree clean afterwards.

*This change was created with AI assistance.*