### PR TITLE
Forward javac notes, including the multi-line ones

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -886,12 +886,15 @@ public class JavacCompiler extends AbstractCompiler {
      * Tells whether a line continues the note that precedes it. Since JDK 21 javac wraps its notes over several
      * lines, indenting every line but the first, while the diagnostics that may follow a note all start in the
      * first column.
+     * <p>
+     * A leading space, not leading whitespace: javac indents note continuations with spaces, whereas a leading tab
+     * marks a stack trace frame, which {@link #STACK_TRACE_OTHER_LINE} is waiting for.
      *
      * @param line the line following a note
      * @return whether the line belongs to that note
      */
     private static boolean isNoteContinuation(String line) {
-        return !line.trim().isEmpty() && Character.isWhitespace(line.charAt(0));
+        return line.startsWith(" ");
     }
 
     private static boolean isWarning(String message) {

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -754,10 +754,20 @@ public class JavacCompiler extends AbstractCompiler {
         List<CompilerMessage> errors = new ArrayList<>();
         String line;
         StringBuilder buffer = new StringBuilder();
+        StringBuilder note = null;
         boolean hasPointer = false;
         int stackTraceLineCount = 0;
 
         while ((line = input.readLine()) != null) {
+            if (note != null) {
+                if (isNoteContinuation(line)) {
+                    note.append(EOL).append(line);
+                    continue;
+                }
+                errors.add(new CompilerMessage(note.toString(), CompilerMessage.Kind.NOTE));
+                note = null;
+            }
+
             if (stackTraceLineCount == 0 && STACK_TRACE_FIRST_LINE.matcher(line).matches()
                     || STACK_TRACE_OTHER_LINE.matcher(line).matches()) {
                 stackTraceLineCount++;
@@ -782,7 +792,8 @@ public class JavacCompiler extends AbstractCompiler {
                 } else if (isWarning(line)) {
                     errors.add(new CompilerMessage(line, WARNING));
                 } else if (isNote(line)) {
-                    // skip, JDK telling us deprecated APIs are used but -Xlint:deprecation isn't set
+                    // held back until its continuation lines, if any, have been read
+                    note = new StringBuilder(line);
                 } else if (isMisc(line)) {
                     // verbose output was set
                     errors.add(new CompilerMessage(line, CompilerMessage.Kind.OTHER));
@@ -798,6 +809,10 @@ public class JavacCompiler extends AbstractCompiler {
             if (line.endsWith("^")) {
                 hasPointer = true;
             }
+        }
+
+        if (note != null) {
+            errors.add(new CompilerMessage(note.toString(), CompilerMessage.Kind.NOTE));
         }
 
         String bufferContent = buffer.toString();
@@ -865,6 +880,18 @@ public class JavacCompiler extends AbstractCompiler {
 
     private static boolean isNote(String message) {
         return startsWithPrefix(message, NOTE_PREFIXES);
+    }
+
+    /**
+     * Tells whether a line continues the note that precedes it. Since JDK 21 javac wraps its notes over several
+     * lines, indenting every line but the first, while the diagnostics that may follow a note all start in the
+     * first column.
+     *
+     * @param line the line following a note
+     * @return whether the line belongs to that note
+     */
+    private static boolean isNoteContinuation(String line) {
+        return !line.trim().isEmpty() && Character.isWhitespace(line.charAt(0));
     }
 
     private static boolean isWarning(String message) {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.codehaus.plexus.compiler.CompilerMessage;
@@ -49,6 +50,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ErrorMessageParserTest {
     private static final String EOL = System.getProperty("line.separator");
+    private static final String ANNOTATION_PROCESSING_NOTE =
+            "Note: Annotation processing is enabled because one or more processors were found" + EOL
+                    + "  on the class path. A future release of javac may disable annotation processing" + EOL
+                    + "  unless at least one processor is specified by name (-processor), or a search" + EOL
+                    + "  path is specified (--processor-path, --processor-module-path), or annotation" + EOL
+                    + "  processing is enabled explicitly (-proc:only, -proc:full)." + EOL
+                    + "  Use -Xlint:-options to suppress this message." + EOL
+                    + "  Use -proc:none to disable annotation processing." + EOL;
+
     private static final String UNIDENTIFIED_LOG_LINES =
             "These log lines should be cut off\n" + "when preceding known error message headers\n";
 
@@ -1314,6 +1324,75 @@ public class ErrorMessageParserTest {
         assertTrue(
                 messages.stream().anyMatch(m -> m.getMessage().contains("Cannot find annotation method")),
                 "the unclassified warning should survive: " + messages);
+    }
+
+    @Test
+    public void testNoteIsReported() throws IOException {
+        String output = "Note: SomeFile.java uses unchecked or unsafe operations." + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(1, messages.size());
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        assertEquals(
+                "SomeFile.java uses unchecked or unsafe operations.",
+                messages.get(0).getMessage());
+    }
+
+    /**
+     * Since JDK 21 javac wraps its notes over several lines, indenting every line but the first. See
+     * <a href="https://inside.java/2023/07/29/quality-heads-up/">the JDK quality heads-up</a>.
+     */
+    @Test
+    public void testMultiLineNoteIsReportedAsASingleMessage() throws IOException {
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(ANNOTATION_PROCESSING_NOTE)));
+
+        assertEquals(1, messages.size());
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        String message = messages.get(0).getMessage();
+        assertTrue(
+                message.startsWith("Annotation processing is enabled"), "note starts with its first line: " + message);
+        assertTrue(
+                message.contains("Use -proc:none to disable annotation processing."),
+                "note keeps its last line: " + message);
+    }
+
+    /**
+     * The continuation lines of a multi-line note used to fall through to the unclassified buffer, which then
+     * swallowed everything that followed it.
+     */
+    @Test
+    public void testMultiLineNoteDoesNotSwallowLaterDiagnostics() throws IOException {
+        String output = ANNOTATION_PROCESSING_NOTE + "warning: [options] bootstrap class path not set" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(2, messages.size(), "note and warning stay separate: " + messages);
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        assertEquals(CompilerMessage.Kind.WARNING, messages.get(1).getKind());
+        assertEquals("[options] bootstrap class path not set", messages.get(1).getMessage());
+    }
+
+    /**
+     * A failing compile reports whatever the classifiers did not recognise, so note continuation lines left in the
+     * buffer would have surfaced as a compiler error.
+     */
+    @Test
+    public void testMultiLineNoteIsNotReportedAsAnErrorWhenCompilationFails() throws IOException {
+        String output = ANNOTATION_PROCESSING_NOTE + "error: cannot find symbol" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(output)));
+
+        List<CompilerMessage> reportedErrors = messages.stream()
+                .filter(m -> m.getKind() == CompilerMessage.Kind.ERROR)
+                .collect(Collectors.toList());
+
+        assertEquals(1, reportedErrors.size(), "only the real error is an error: " + messages);
+        assertEquals("error: cannot find symbol", reportedErrors.get(0).getMessage());
     }
 
     private void validateBadSourceFile(CompilerMessage message) {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/ErrorMessageParserTest.java
@@ -1391,8 +1391,125 @@ public class ErrorMessageParserTest {
                 .filter(m -> m.getKind() == CompilerMessage.Kind.ERROR)
                 .collect(Collectors.toList());
 
+        assertEquals(2, messages.size(), "the note and the error, nothing else: " + messages);
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
         assertEquals(1, reportedErrors.size(), "only the real error is an error: " + messages);
         assertEquals("error: cannot find symbol", reportedErrors.get(0).getMessage());
+    }
+
+    /**
+     * A note ends at the first line that is not indented, so an anchored diagnostic that follows one keeps its own
+     * identity. This is the interleaving where the note state and the pending-error flush meet.
+     */
+    @Test
+    public void testNoteFollowedByAnchoredDiagnostic() throws IOException {
+        String output = "Note: SomeFile.java uses unchecked or unsafe operations." + EOL
+                + "target/compiler-src/Foo.java:1: warning: something is off" + EOL
+                + "public class Foo {}" + EOL
+                + "       ^" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(2, messages.size(), "note and diagnostic stay separate: " + messages);
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        assertEquals(CompilerMessage.Kind.WARNING, messages.get(1).getKind());
+        assertEquals("target/compiler-src/Foo.java", messages.get(1).getFile());
+    }
+
+    /**
+     * The reverse order, which exercises the pending-error flush running before a note is recognised.
+     */
+    @Test
+    public void testAnchoredDiagnosticFollowedByNote() throws IOException {
+        String output = "target/compiler-src/Foo.java:1: warning: something is off" + EOL
+                + "public class Foo {}" + EOL
+                + "       ^" + EOL
+                + "Note: Recompile with -Xlint:unchecked for details." + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(2, messages.size(), "diagnostic and note stay separate: " + messages);
+        assertEquals(CompilerMessage.Kind.WARNING, messages.get(0).getKind());
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(1).getKind());
+        assertEquals(
+                "Recompile with -Xlint:unchecked for details.", messages.get(1).getMessage());
+    }
+
+    /**
+     * The deprecation and unchecked notes always arrive as a pair of single-line notes.
+     */
+    @Test
+    public void testConsecutiveNotesStaySeparate() throws IOException {
+        String output = "Note: Some input files use or override a deprecated API." + EOL
+                + "Note: Recompile with -Xlint:deprecation for details." + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(2, messages.size(), "two notes: " + messages);
+        assertEquals(
+                "Some input files use or override a deprecated API.",
+                messages.get(0).getMessage());
+        assertEquals(
+                "Recompile with -Xlint:deprecation for details.",
+                messages.get(1).getMessage());
+    }
+
+    /**
+     * A note that runs to the end of the stream is flushed after the loop, and a failing compile must not report it
+     * a second time as unrecognised output.
+     */
+    @Test
+    public void testMultiLineNoteAtEndOfStreamIsReportedOnceWhenCompilationFails() throws IOException {
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(ANNOTATION_PROCESSING_NOTE)));
+
+        assertEquals(1, messages.size(), "the note is the only message: " + messages);
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+    }
+
+    /**
+     * Stack trace frames are indented with a tab rather than a space, so a crash dump that follows a note is not
+     * absorbed into it.
+     */
+    @Test
+    public void testTabIndentedStackTraceDoesNotContinueANote() throws IOException {
+        String output = "Note: SomeFile.java uses unchecked or unsafe operations." + EOL
+                + "\tat com.sun.tools.javac.comp.Attr.visitIdent(Attr.java:1)" + EOL
+                + "\tat com.sun.tools.javac.tree.JCTree.accept(JCTree.java:2)" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(1, new BufferedReader(new StringReader(output)));
+
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        assertEquals(
+                "SomeFile.java uses unchecked or unsafe operations.",
+                messages.get(0).getMessage());
+        assertTrue(
+                messages.stream()
+                        .anyMatch(m -> m.getKind() == CompilerMessage.Kind.ERROR
+                                && m.getMessage().contains("visitIdent")),
+                "the stack trace is reported on its own: " + messages);
+    }
+
+    /**
+     * Only the English prefix is stripped from a note, so a localised one keeps its own. Pinned here because the
+     * asymmetry lives in the shared API module and outlives this parser.
+     */
+    @Test
+    public void testLocalisedNoteKeepsItsPrefixAndItsContinuation() throws IOException {
+        String output = "\u6ce8: \u6ce8\u91c8\u51e6\u7406\u304c\u6709\u52b9\u3067\u3059" + EOL
+                + "  \u30af\u30e9\u30b9\u30d1\u30b9\u4e0a\u306b\u898b\u3064\u304b\u308a\u307e\u3057\u305f" + EOL;
+
+        List<CompilerMessage> messages =
+                JavacCompiler.parseModernStream(0, new BufferedReader(new StringReader(output)));
+
+        assertEquals(1, messages.size(), "one note: " + messages);
+        assertEquals(CompilerMessage.Kind.NOTE, messages.get(0).getKind());
+        assertTrue(messages.get(0).getMessage().startsWith("\u6ce8: "), "prefix is kept for a localised note");
+        assertTrue(messages.get(0).getMessage().contains("\u30af\u30e9\u30b9"), "continuation is kept");
     }
 
     private void validateBadSourceFile(CompilerMessage message) {


### PR DESCRIPTION
Forked javac was the only back-end dropping notes: `JavaxToolsCompiler.convertKind` already maps `Diagnostic.Kind.NOTE`, and the eclipse compiler emits `Kind.NOTE` too, so `testForkedAndInProcessDiagnosticsAreEqual` held only because the test input produces no notes.

The reason this is not the one-line change #312 proposed: javac can wrap a note over several lines, indenting every line but the first. Those continuation lines match no classifier, so they land in the unclassified buffer, and once that buffer is non-empty everything after it joins in — the note reappearing glued to the front of the next warning, [as reported on #312](https://github.com/codehaus-plexus/plexus-compiler/pull/312#issuecomment-1827716943). Since 880da00f a failing compile reports that buffer as an error, so the note could surface as a compiler error assembled out of note text.

The note that prompted this, about annotation processing being enabled, is a JDK 21/22 one — JDK 23 made annotation processing opt-in, and JDK 25 stays silent even with a processor on the class path. The handling here is general, because nothing stops a future note from wrapping.

Continuation is a leading space, not leading whitespace: a leading tab marks a stack trace frame, and a crash dump printed straight after a note must not be absorbed into it.

Notes now carry the `Recompile with -Xlint:deprecation for details` hint that #183 asks for. #183 also wants the lint category on warnings themselves, which is a separate question, so this does not close it.

Not addressed here: `CompilerMessage` strips only the English `note: ` prefix while `JavacCompiler.NOTE_PREFIXES` is multilingual, so a localised note keeps its prefix. That predates this change, applies equally to warnings, and lives in the shared API module; there is a test pinning the current behaviour.

The shared TCK counts every non-error message as a warning (`AbstractCompilerTest`: `messages.size() - numCompilerErrors`). It does not bite here — `AbstractJavacCompilerTest` sets `-deprecation`, so javac emits real warnings instead of the deprecation notes — but it is worth tightening separately.

This takes only the javac half of #312. The eclipse `-log` half needs the `CompilerConfiguration` option @gnodet [proposed against his own patch](https://github.com/codehaus-plexus/plexus-compiler/pull/312#issuecomment-1783776227) rather than a rebase.

Verified: `mvn install` on JDK 25, whole reactor green; reverting the continuation predicate to leading whitespace fails exactly one test.

*This change was created with AI assistance.*
