### PR TITLE
Count warnings by kind, not by subtraction

### DIFF
--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -139,7 +139,7 @@ public abstract class AbstractCompilerTest {
 
         int numCompilerErrors = compilerErrorCount(messages);
 
-        int numCompilerWarnings = messages.size() - numCompilerErrors;
+        int numCompilerWarnings = compilerWarningCount(messages);
 
         int expectedErrors = expectedErrors();
 
@@ -169,16 +169,16 @@ public abstract class AbstractCompilerTest {
         if (expectedWarnings != numCompilerWarnings) {
             List<String> warnings = new ArrayList<>();
             System.out.println(numCompilerWarnings + " warning(s) found:");
-            for (CompilerMessage error : messages) {
-                if (error.isError()) {
+            for (CompilerMessage warning : messages) {
+                if (!isWarning(warning)) {
                     continue;
                 }
 
                 System.out.println("----");
-                System.out.println(error.getFile());
-                System.out.println(error.getMessage());
+                System.out.println(warning.getFile());
+                System.out.println(warning.getMessage());
                 System.out.println("----");
-                warnings.add(error.getMessage());
+                warnings.add(warning.getMessage());
             }
 
             assertEquals(
@@ -277,6 +277,21 @@ public abstract class AbstractCompilerTest {
         }
 
         return count;
+    }
+
+    protected int compilerWarningCount(List<CompilerMessage> messages) {
+        int count = 0;
+
+        for (CompilerMessage message : messages) {
+            count += isWarning(message) ? 1 : 0;
+        }
+
+        return count;
+    }
+
+    private static boolean isWarning(CompilerMessage message) {
+        return message.getKind() == CompilerMessage.Kind.WARNING
+                || message.getKind() == CompilerMessage.Kind.MANDATORY_WARNING;
     }
 
     protected int expectedErrors() {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/JavaxToolsCompilerTest.java
@@ -23,14 +23,4 @@ package org.codehaus.plexus.compiler.javac;
  */
 public class JavaxToolsCompilerTest extends AbstractJavacCompilerTest {
     // no op default is to javax.tools if available
-
-    @Override
-    protected int expectedWarnings() {
-        String javaVersion = getJavaVersion();
-        if (javaVersion.contains("21") || javaVersion.contains("25")) {
-            return 1;
-        } else {
-            return super.expectedWarnings();
-        }
-    }
 }


### PR DESCRIPTION
`AbstractCompilerTest` derived the warning count as everything that is not an error, which makes a `NOTE` or an `OTHER` message a warning. Both kinds are already in use — eclipse maps its informational problems to `NOTE`, in-process javac maps `Diagnostic.Kind.NOTE` straight through, and `javac -verbose` output arrives as `OTHER` — so a compiler that says more failed the test that counts.

Nothing in this repository was miscounting: the fixtures produce neither notes nor verbose output today, which is why the arithmetic survived. This is a base class in a published artifact though, extended by compilers outside this repository, so the assumption is not only ours to hit. #496 also makes forked javac emit notes, and this removes the trap it would otherwise leave for anyone whose fixtures do produce one.

No expected count is adjusted. The `JavaxToolsCompilerTest` warning override goes too — it returned the same `1` as the superclass on every JDK in the matrix, while reading as though in-process compilation counted differently.

Independent of #496; either can go first.

Verified: `mvn clean install` on JDK 25, whole reactor green.

*This change was created with AI assistance.*
