### PR TITLE
Depend on the resolver directly instead of maven-core

### DIFF
--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -33,14 +33,14 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>${mavenVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${mavenResolverVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTckTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTckTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractCompilerTckTest {
         File compilerOutput = getCompilerOutput();
 
         if (compilerOutput.exists()) {
-            org.apache.commons.io.FileUtils.deleteDirectory(compilerOutput);
+            FileUtils.deleteDirectory(compilerOutput);
         }
 
         configuration.setOutputLocation(compilerOutput.getAbsolutePath());

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -34,16 +34,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.maven.RepositoryUtils;
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.LocalRepositoryProvider;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
@@ -292,18 +289,7 @@ public abstract class AbstractCompilerTest {
     }
 
     protected File getLocalArtifactPath(String groupId, String artifactId, String version, String type) {
-        VersionRange versionRange = VersionRange.createFromVersion(version);
-
-        Artifact artifact = new DefaultArtifact(
-                groupId,
-                artifactId,
-                versionRange,
-                Artifact.SCOPE_COMPILE,
-                type,
-                null,
-                new DefaultArtifactHandler(type));
-
-        return getLocalArtifactPath(artifact);
+        return getLocalArtifactPath(new DefaultArtifact(groupId, artifactId, type, version));
     }
 
     protected String getJavaVersion() {
@@ -331,6 +317,6 @@ public abstract class AbstractCompilerTest {
     protected File getLocalArtifactPath(Artifact artifact) {
         return new File(
                 localRepositoryManager.getRepository().getBasedir(),
-                localRepositoryManager.getPathForLocalArtifact(RepositoryUtils.toArtifact(artifact)));
+                localRepositoryManager.getPathForLocalArtifact(artifact));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2026-01-25T22:48:03Z</project.build.outputTimestamp>
     <aspectj.version>1.9.21</aspectj.version>
-    <mavenVersion>3.8.1</mavenVersion>
+    <mavenResolverVersion>1.9.27</mavenResolverVersion>
     <errorprone.version>2.37.0</errorprone.version>
     <eclipse.sisu.version>1.1.0</eclipse.sisu.version>
     <trimStackTrace>false</trimStackTrace>


### PR DESCRIPTION
The TCK needed one thing from Maven: a path inside the local repository. It got there by building an `org.apache.maven.artifact.Artifact` and handing it to `RepositoryUtils.toArtifact`, which converts it into the `org.eclipse.aether.artifact.Artifact` that `LocalRepositoryManager` wanted in the first place. Building the resolver artifact directly removes the round trip, and that was the only use `maven-core` and `maven-artifact` had here.

What they were dragging in is the point. `maven-core` 3.8.1 brings `maven-shared-utils` 3.2.1 (CVE-2022-29599, critical) and through it `commons-io` 2.5 (CVE-2024-47554, CVE-2021-29425); `maven-artifact` brings `commons-lang3` 3.8.1 (CVE-2025-48924). **28 of this repository's 36 Dependabot alerts are those four**, counted once per module that resolves them. None of that code is reachable from a test harness, but they are compile-scope dependencies of a published artifact, so they land on the classpath of everyone extending it.

`AbstractCompilerTckTest` was calling `org.apache.commons.io.FileUtils`, which compiled only because commons-io arrived transitively through maven-shared-utils — an undeclared dependency that the removal exposed. `plexus-utils`, already imported in that file, has `deleteDirectory` too.

maven-resolver 1.9.27 is what Maven 3.9.16 ships, so the declared version matches what the runtime already provides.

**API break worth a deliberate decision:** `getLocalArtifactPath(Artifact)` now takes the resolver's `Artifact` instead of Maven's. It is `protected` on a base class in a published artifact, so a downstream TCK subclass calling that overload would need a one-line change. The `getLocalArtifactPath(String, String, String, String)` overload beside it — the only one anything in this repository calls — is unchanged.

The remaining alerts are `commons-lang` 2.6 (×7, deliberate: it is compile-classpath fixture data for `ExternalDeps.java`, compiled but never executed) and one Jenkins `remoting` alert inside an integration-test reproducer pom that is not built by the reactor.

Verified: `mvn clean install` on JDK 25, whole reactor green; `dependency:tree` across the reactor no longer mentions maven-core, maven-artifact, maven-shared-utils, commons-io or commons-lang3.

*This change was created with AI assistance.*
