### PR TITLE
Remove the Maven and commons-lang dependencies from the compiler TCK

### DIFF
--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -33,16 +33,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-api</artifactId>
-      <version>${mavenResolverVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-impl</artifactId>
-      <version>${mavenResolverVersion}</version>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>
@@ -50,7 +40,7 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
     </dependency>
-    <!-- This just needs to be present in the local repository for tests to pass. It would be preferable for the tests to resolve it directly -->
+    <!-- On the classpath the TCK hands to the compiler under test, for the test-input sources that import it -->
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>

--- a/plexus-compiler-test/pom.xml
+++ b/plexus-compiler-test/pom.xml
@@ -42,9 +42,9 @@
     </dependency>
     <!-- On the classpath the TCK hands to the compiler under test, for the test-input sources that import it -->
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.20.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractCompilerTest {
     protected List<String> getClasspath() throws Exception {
         List<String> cp = new ArrayList<>();
 
-        cp.add(getJarPath("org.apache.commons.lang.StringUtils").getAbsolutePath());
+        cp.add(getJarPath("org.apache.commons.lang3.StringUtils").getAbsolutePath());
 
         return cp;
     }

--- a/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
+++ b/plexus-compiler-test/src/main/java/org/codehaus/plexus/compiler/AbstractCompilerTest.java
@@ -26,6 +26,7 @@ package org.codehaus.plexus.compiler;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -37,14 +38,6 @@ import java.util.stream.Collectors;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
-import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.impl.LocalRepositoryProvider;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,27 +58,7 @@ public abstract class AbstractCompilerTest {
     @Inject
     private Map<String, Compiler> compilers;
 
-    @Inject
-    private LocalRepositoryProvider localRepositoryProvider;
-
-    private LocalRepositoryManager localRepositoryManager;
-
     protected abstract String getRoleHint();
-
-    @BeforeEach
-    final void setUpLocalRepo() throws Exception {
-        String localRepo = System.getProperty("maven.repo.local");
-        assertNotNull(localRepo, "system property maven.repo.local");
-
-        LocalRepository localRepository = new LocalRepository(localRepo);
-        File basedir = localRepository.getBasedir();
-        assertTrue(
-                basedir != null && basedir.exists() && basedir.canRead(),
-                "test prerequisite: local repository path: " + basedir);
-
-        RepositorySystemSession session = new DefaultRepositorySystemSession();
-        localRepositoryManager = localRepositoryProvider.newLocalRepositoryManager(session, localRepository);
-    }
 
     protected void setCompilerDebug(boolean flag) {
         compilerDebug = flag;
@@ -106,15 +79,28 @@ public abstract class AbstractCompilerTest {
     protected List<String> getClasspath() throws Exception {
         List<String> cp = new ArrayList<>();
 
-        File file = getLocalArtifactPath("commons-lang", "commons-lang", "2.6", "jar");
-
-        assertTrue(
-                file != null && file.exists() && file.canRead(),
-                "test prerequisite: commons-lang library must be available in local repository at " + file);
-
-        cp.add(file.getAbsolutePath());
+        cp.add(getJarPath("org.apache.commons.lang.StringUtils").getAbsolutePath());
 
         return cp;
+    }
+
+    /**
+     * Locates the jar a class was loaded from, so that a test can put a dependency of its own on the classpath it
+     * asks the compiler to use. The dependency is declared in the pom like any other, and found here through the
+     * class loader rather than by guessing at a path inside the local repository.
+     *
+     * @param className fully qualified name of a class in the wanted jar
+     * @return the jar holding that class
+     */
+    protected static File getJarPath(String className) throws Exception {
+        Class<?> type = Class.forName(className);
+        CodeSource source = type.getProtectionDomain().getCodeSource();
+        assertNotNull(source, "test prerequisite: no code source for " + className);
+
+        File jar = new File(source.getLocation().toURI());
+        assertTrue(jar.canRead(), "test prerequisite: unreadable jar for " + className + ": " + jar);
+
+        return jar;
     }
 
     protected void configureCompilerConfig(CompilerConfiguration compilerConfig) {}
@@ -303,10 +289,6 @@ public abstract class AbstractCompilerTest {
         return Collections.emptyList();
     }
 
-    protected File getLocalArtifactPath(String groupId, String artifactId, String version, String type) {
-        return getLocalArtifactPath(new DefaultArtifact(groupId, artifactId, type, version));
-    }
-
     protected String getJavaVersion() {
         String javaVersion = System.getProperty("java.version");
         String realJavaVersion = javaVersion;
@@ -327,11 +309,5 @@ public abstract class AbstractCompilerTest {
                 + "\n");
 
         return javaVersion;
-    }
-
-    protected File getLocalArtifactPath(Artifact artifact) {
-        return new File(
-                localRepositoryManager.getRepository().getBasedir(),
-                localRepositoryManager.getPathForLocalArtifact(artifact));
     }
 }

--- a/plexus-compilers/plexus-compiler-aspectj/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
@@ -1,7 +1,7 @@
 package org.codehaus.foo;
 
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 public class ExternalDeps

--- a/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-aspectj/src/test/java/org/codehaus/plexus/compiler/ajc/AspectJCompilerTest.java
@@ -1,6 +1,5 @@
 package org.codehaus.plexus.compiler.ajc;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -28,9 +27,7 @@ public class AspectJCompilerTest extends AbstractCompilerTest {
     @Override
     protected List<String> getClasspath() throws Exception {
         List<String> classpath = super.getClasspath();
-        String aspectjVersion = System.getProperty("aspectj.version");
-        File aspectjRuntime = getLocalArtifactPath("org.aspectj", "aspectjrt", aspectjVersion, "jar");
-        classpath.add(aspectjRuntime.getAbsolutePath());
+        classpath.add(getJarPath("org.aspectj.lang.JoinPoint").getAbsolutePath());
         return classpath;
     }
 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
@@ -1,7 +1,7 @@
 package org.codehaus.foo;
 
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 public class ExternalDeps

--- a/plexus-compilers/plexus-compiler-javac/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test-input/src/main/org/codehaus/foo/ExternalDeps.java
@@ -1,6 +1,6 @@
 package org.codehaus.foo;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class ExternalDeps
 {

--- a/plexus-compilers/pom.xml
+++ b/plexus-compilers/pom.xml
@@ -36,13 +36,6 @@
       <artifactId>plexus-compiler-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- this is used for populating a test classpath in AbstractCompiler and is required in the local repository -->
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2026-01-25T22:48:03Z</project.build.outputTimestamp>
     <aspectj.version>1.9.21</aspectj.version>
-    <mavenResolverVersion>1.9.27</mavenResolverVersion>
     <errorprone.version>2.37.0</errorprone.version>
     <eclipse.sisu.version>1.1.0</eclipse.sisu.version>
     <trimStackTrace>false</trimStackTrace>
@@ -142,9 +141,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-            <systemPropertyVariables>
-              <maven.repo.local>${settings.localRepository}</maven.repo.local>
-            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This change follows #498, which replaced `maven-core` with the Maven resolver. The resolver isn't needed either.

The TCK builds a classpath for the compiler under test from two JAR files: one library for the `ExternalDeps.java` test input to resolve, and the `aspectjrt` library for the AspectJ module. Each module that needs one of them declares it as a dependency, so both are on the test JVM classpath before the test runs. Locating them by path inside the local repository duplicates that resolution, and it requires an injected `LocalRepositoryProvider` object, a `DefaultRepositorySystemSession` object, and a `maven.repo.local` system property set by the Maven Surefire plugin. Asking the class loader where a class came from replaces all three.

A comment beside that dependency asks for this: "it would be preferable for the tests to resolve it directly".

After this change, the `plexus-compiler-test` artifact depends on no part of Maven. Its dependencies are `javax.inject`, `plexus-compiler-api`, `junit-jupiter-api`, `plexus-testing`, `plexus-utils`, `plexus-xml`, and the fixture library.

The second commit changes that fixture library from `commons-lang` 2.6, whose last release was in 2011, to `commons-lang3` 3.20.0. The `StringUtils.upperCase` method is the only method that the `ExternalDeps.java` file calls, and both libraries provide it. The `plexus-compilers/pom.xml` file declares the same library a second time, for a reason its own comment gives: "is required in the local repository". The first commit makes that untrue.

Together with #498, this leaves one Dependabot alert on the repository, for the Jenkins `remoting` library in an integration-test reproducer POM that the reactor doesn't build.

**API change**: both overloads of `getLocalArtifactPath` are replaced by the `getJarPath` method, which takes a class name rather than artifact coordinates. Both are `protected` methods on a base class in a published artifact, so a TCK subclass outside this repository needs a one-line change. That's the same consideration as #498, and an argument for releasing this in 2.17.0 rather than in a patch version.

Verified: `dependency:tree` across the reactor reports no Maven artifact and no `commons-lang`. The `AspectJCompilerTest` class compiles the `ExternalDeps.java` file and asserts `ExternalDeps.class` among its outputs, so both classpath entries are in use.

*This change was created with AI assistance.*
