### PR TITLE
Bump remoting in the MCOMPILER-346 reproducer

### DIFF
--- a/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/pom.xml
+++ b/plexus-compiler-its/src/main/it/MCOMPILER-346-mre/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>remoting</artifactId>
-      <version>3.2</version>
+      <version>3386.v353e57a_1b_ea_0</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
This change bumps the `remoting` dependency in the MCOMPILER-346 reproducer from version 3.2 to 3386.v353e57a_1b_ea_0, clearing CVE-2024-43044.

The reproducer isn't inert. The `maven-invoker-plugin` runs `src/main/it` during the `verify` phase with no profile guard, so the dependency resolves on every build. Nothing executes it, so the vulnerability isn't reachable, but the alert is accurate about the artifact being fetched.

The test asserts that a failing compile reports two named packages as missing, which means a bump has to leave the javac error set alone. The `org.jenkinsci.remoting.RoleChecker` class still resolves in the new version, and javac reports the same five packages missing the same number of times as before.

With #498 and #499, this leaves no Dependabot alert naming a dependency that the build resolves. The seven `commons-lang` alerts still listed refer to an artifact that master no longer declares, so they close on the next scan.

Verified: the `does not exist` lines in the `build.log` file are identical before and after the bump.

*This change was created with AI assistance.*
