### PR TITLE
Update parent to plexus 27

### DIFF
--- a/plexus-compiler-its/pom.xml
+++ b/plexus-compiler-its/pom.xml
@@ -46,7 +46,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.10.1</version>
         <executions>
           <execution>
             <id>integration-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>26</version>
+    <version>27</version>
   </parent>
 
   <artifactId>plexus-compiler</artifactId>
@@ -50,7 +50,8 @@
     <eclipse.sisu.version>1.1.0</eclipse.sisu.version>
     <trimStackTrace>false</trimStackTrace>
     <preparationGoals>clean install</preparationGoals>
-    <maven.compiler.version>3.15.0</maven.compiler.version>
+    <!-- interpolated into the IT projects, which do not inherit this parent -->
+    <maven.compiler.version>${version.maven-compiler-plugin}</maven.compiler.version>
   </properties>
 
   <dependencyManagement>
@@ -146,7 +147,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven.compiler.version}</version>
           <configuration>
             <proc>none</proc>
           </configuration>


### PR DESCRIPTION
Second pilot of the parent bumps. 27 renames managed versions to `version.<artifactId>`, which lets two local pins go: maven-compiler-plugin and maven-invoker-plugin now take their versions from the parent.

`maven.compiler.version` stays. plexus-compiler-its interpolates `@maven.compiler.version@` into IT projects that do not inherit this parent, so removing it fails them with `maven-compiler-plugin:@maven.compiler.version@`. It now reads `${version.maven-compiler-plugin}`, so the ITs cannot test a different plugin version than the build uses.

Verified: `mvn clean verify` green, ITs included.

*This change was created with AI assistance.*