### PR TITLE
Bump the plexus dependencies released today

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-testing</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -124,7 +124,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
plexus-testing 2.1.0 to 2.2.0. plexus-xml 3.0.1 to 3.1.0. 

Raised by hand rather than waiting for dependabot, so the pins are current before this project's own release is cut.

Verified: `mvn clean verify` green.

*This change was created with AI assistance.*