### PR TITLE
Point the SCM URLs at HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <connection>${scm.url}</connection>
     <developerConnection>${scm.url}</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
+    <url>https://github.com/codehaus-plexus/plexus-compiler/tree/${project.scm.tag}/</url>
   </scm>
   <issueManagement>
     <system>github</system>
@@ -41,7 +41,7 @@
   </distributionManagement>
 
   <properties>
-    <scm.url>scm:git:git@github.com:codehaus-plexus/plexus-compiler.git</scm.url>
+    <scm.url>scm:git:https://github.com/codehaus-plexus/plexus-compiler.git</scm.url>
     <javaVersion>8</javaVersion>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <project.build.outputTimestamp>2026-08-19T16:04:03Z</project.build.outputTimestamp>


### PR DESCRIPTION
`connection` is meant to be the anonymous, read-only URL, and both it and `developerConnection` here are
the scp-like SSH form. That makes a release depend on the releaser having an SSH key configured, and gives
anonymous consumers a URL they cannot use.

Every other component in the org uses the HTTPS URL, which works through the git credential helper. Same
change as codehaus-plexus/plexus-sec-dispatcher#142, where the SSH form was not merely inconvenient but
malformed and blocked the release outright.

*This change was created with AI assistance.*