### PR TITLE
Stop pinning a version in the README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ To write against the API:
 <dependency>
   <groupId>org.codehaus.plexus</groupId>
   <artifactId>plexus-compiler-api</artifactId>
-  <version>2.16.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The snippet pinned a version, so it went stale the moment the next release went out — most of these were
advertising the version before the one on Central, and plexus-archiver was offering a 5.0.0 that has never
been released.

Dropping the `<version>` element leaves the Maven Central badge at the top of the page as the single source
of truth, which is where the "Check the badge above for the current version." line was already sending people.

*This change was created with AI assistance.*