### PR TITLE
Fix aspectj-compiler IT for Maven 4 stdout prefixing

### DIFF
--- a/plexus-compiler-its/src/main/it/aspectj-compiler/verify.groovy
+++ b/plexus-compiler-its/src/main/it/aspectj-compiler/verify.groovy
@@ -32,4 +32,11 @@ Running application
 execution(String org.acme.Application.greet(String))
 call(void org.junit.Assert.assertTrue(boolean))""".normalize()
 
-assert content.contains( junitLog )
+// Maven 4's console reporter prefixes surefire lines with "[INFO] " and forked
+// test stdout with "[INFO] [stdout] "; strip those so the woven-output block
+// matches under both Maven 3 (unprefixed) and Maven 4.
+def unprefixed = content.readLines()
+    .collect { it.replaceFirst( ~/^\[INFO\] (\[stdout\] )?/, '' ) }
+    .join( '\n' )
+
+assert unprefixed.contains( junitLog )


### PR DESCRIPTION
## Problem

The `aspectj-compiler` integration test fails under Maven 4.0.0-rc-6. The IT's *inner* build is `BUILD SUCCESS`; the `verify.groovy` post-build script fails asserting that a raw, contiguous block of AspectJ-woven test output appears in `build.log`.

## Root cause

Maven 4's console reporter prefixes surefire lines with `[INFO] ` and forked test stdout with `[INFO] [stdout] `, so the expected block is no longer a verbatim substring. Maven 3.9 / 3.10 print the block unprefixed, which is why the IT passes there.

It is Maven-4-specific rather than a resolver change: on CI, `3.10.0-rc-1` passes and `4.0.0-rc-6` fails, and both ship the same maven-resolver (2.0.21).

## Change

Strip the `[INFO] ` / `[INFO] [stdout] ` line prefixes before the `contains` check — a no-op under Maven 3, matching under Maven 4.

## Verification

- Local: `mvn verify -Dinvoker.test=aspectj-compiler` under 4.0.0-rc-6 + Temurin 21 → pass.
- CI (my fork): temurin × {ubuntu, windows, macOS} × JDK 17/21/25 — Maven 4.0.0-rc-6 all green, Maven 3.9.11 all green, and a 3.10.0-rc-1 control green:
  https://github.com/aschemaven/plexus-compiler/actions/runs/32296953979

Closes #508

_No CI changes are included here; enabling a Maven 4 job in the shared CI is a separate discussion._
