### PR TITLE
Skip blank annotation processor names in javac and eclipse

### DIFF
--- a/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
+++ b/plexus-compiler-api/src/main/java/org/codehaus/plexus/compiler/AbstractCompiler.java
@@ -295,4 +295,31 @@ public abstract class AbstractCompiler implements Compiler {
         }
         return to;
     }
+
+    /**
+     * Joins the configured annotation processor names, skipping blank entries.
+     * <p>
+     * Maven maps an explicitly empty {@code <annotationProcessors/>} element to an array holding
+     * blank strings rather than to an empty array. Passing those on yields {@code -processor} with
+     * an empty processor name, which no compiler can resolve. Callers should omit the option
+     * entirely when this returns an empty string.
+     *
+     * @param annotationProcessors the configured names, possibly {@code null}
+     * @return the non-blank names joined by commas, or an empty string if none remain
+     * @since 2.17.1
+     */
+    protected static String joinAnnotationProcessors(String[] annotationProcessors) {
+        StringBuilder buffer = new StringBuilder();
+        if (annotationProcessors != null) {
+            for (String annotationProcessor : annotationProcessors) {
+                if (annotationProcessor != null && !annotationProcessor.trim().isEmpty()) {
+                    if (buffer.length() > 0) {
+                        buffer.append(',');
+                    }
+                    buffer.append(annotationProcessor);
+                }
+            }
+        }
+        return buffer.toString();
+    }
 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -173,23 +173,16 @@ public class EclipseJavaCompiler extends AbstractCompiler {
             }
 
             // now add jdk 1.6 annotation processing related parameters
-            String[] annotationProcessors = config.getAnnotationProcessors();
+            String annotationProcessors = joinAnnotationProcessors(config.getAnnotationProcessors());
             List<String> processorPathEntries = config.getProcessorPathEntries();
             List<String> processorModulePathEntries = config.getProcessorModulePathEntries();
 
-            if ((annotationProcessors != null && annotationProcessors.length > 0)
+            if (!annotationProcessors.isEmpty()
                     || (processorPathEntries != null && processorPathEntries.size() > 0)
                     || (processorModulePathEntries != null && processorModulePathEntries.size() > 0)) {
-                if (annotationProcessors != null && annotationProcessors.length > 0) {
+                if (!annotationProcessors.isEmpty()) {
                     args.add("-processor");
-                    StringBuilder sb = new StringBuilder();
-                    for (String ap : annotationProcessors) {
-                        if (sb.length() > 0) {
-                            sb.append(',');
-                        }
-                        sb.append(ap);
-                    }
-                    args.add(sb.toString());
+                    args.add(annotationProcessors);
                 }
 
                 if (processorPathEntries != null && processorPathEntries.size() > 0) {
@@ -624,5 +617,30 @@ public class EclipseJavaCompiler extends AbstractCompiler {
             return "9";
         }
         return versionSpec;
+    }
+
+    /**
+     * Joins the configured annotation processor names, skipping blank entries.
+     * <p>
+     * Maven maps an explicitly empty {@code <annotationProcessors/>} element to an array of blank
+     * strings rather than to an empty array, and passing those on produces {@code -processor} with
+     * an empty processor name.
+     *
+     * @param annotationProcessors the configured names, possibly {@code null}
+     * @return the non-blank names joined by commas, or an empty string if there are none
+     */
+    private static String joinAnnotationProcessors(String[] annotationProcessors) {
+        StringBuilder buffer = new StringBuilder();
+        if (annotationProcessors != null) {
+            for (String annotationProcessor : annotationProcessors) {
+                if (annotationProcessor != null && !annotationProcessor.trim().isEmpty()) {
+                    if (buffer.length() > 0) {
+                        buffer.append(',');
+                    }
+                    buffer.append(annotationProcessor);
+                }
+            }
+        }
+        return buffer.toString();
     }
 }

--- a/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
+++ b/plexus-compilers/plexus-compiler-eclipse/src/main/java/org/codehaus/plexus/compiler/eclipse/EclipseJavaCompiler.java
@@ -618,29 +618,4 @@ public class EclipseJavaCompiler extends AbstractCompiler {
         }
         return versionSpec;
     }
-
-    /**
-     * Joins the configured annotation processor names, skipping blank entries.
-     * <p>
-     * Maven maps an explicitly empty {@code <annotationProcessors/>} element to an array of blank
-     * strings rather than to an empty array, and passing those on produces {@code -processor} with
-     * an empty processor name.
-     *
-     * @param annotationProcessors the configured names, possibly {@code null}
-     * @return the non-blank names joined by commas, or an empty string if there are none
-     */
-    private static String joinAnnotationProcessors(String[] annotationProcessors) {
-        StringBuilder buffer = new StringBuilder();
-        if (annotationProcessors != null) {
-            for (String annotationProcessor : annotationProcessors) {
-                if (annotationProcessor != null && !annotationProcessor.trim().isEmpty()) {
-                    if (buffer.length() > 0) {
-                        buffer.append(',');
-                    }
-                    buffer.append(annotationProcessor);
-                }
-            }
-        }
-        return buffer.toString();
-    }
 }

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -371,6 +371,31 @@ public class JavacCompiler extends AbstractCompiler {
         return buildCompilerArguments(config, getSourceFiles(config), javacVersion);
     }
 
+    /**
+     * Joins the configured annotation processor names, skipping blank entries.
+     * <p>
+     * Maven maps an explicitly empty {@code <annotationProcessors/>} element to an array of blank
+     * strings rather than to an empty array, and passing those on produces {@code -processor} with
+     * an empty processor name, which javac cannot resolve.
+     *
+     * @param annotationProcessors the configured names, possibly {@code null}
+     * @return the non-blank names joined by commas, or an empty string if there are none
+     */
+    private static String joinAnnotationProcessors(String[] annotationProcessors) {
+        StringBuilder buffer = new StringBuilder();
+        if (annotationProcessors != null) {
+            for (String annotationProcessor : annotationProcessors) {
+                if (annotationProcessor != null && !annotationProcessor.trim().isEmpty()) {
+                    if (buffer.length() > 0) {
+                        buffer.append(",");
+                    }
+                    buffer.append(annotationProcessor);
+                }
+            }
+        }
+        return buffer.toString();
+    }
+
     public static String[] buildCompilerArguments(
             CompilerConfiguration config, String[] sourceFiles, String javacVersion) {
         List<String> args = new ArrayList<>();
@@ -421,17 +446,10 @@ public class JavacCompiler extends AbstractCompiler {
             if (config.getProc() != null) {
                 args.add("-proc:" + config.getProc());
             }
-            String[] annotationProcessors = config.getAnnotationProcessors();
-            if (annotationProcessors != null && annotationProcessors.length > 0) {
+            String annotationProcessors = joinAnnotationProcessors(config.getAnnotationProcessors());
+            if (!annotationProcessors.isEmpty()) {
                 args.add("-processor");
-                StringBuilder buffer = new StringBuilder();
-                for (int i = 0; i < annotationProcessors.length; i++) {
-                    if (i > 0) {
-                        buffer.append(",");
-                    }
-                    buffer.append(annotationProcessors[i]);
-                }
-                args.add(buffer.toString());
+                args.add(annotationProcessors);
             }
             if (config.getProcessorPathEntries() != null
                     && !config.getProcessorPathEntries().isEmpty()) {

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -421,15 +421,15 @@ public class JavacCompiler extends AbstractCompiler {
             if (config.getProc() != null) {
                 args.add("-proc:" + config.getProc());
             }
-            if (config.getAnnotationProcessors() != null) {
+            String[] annotationProcessors = config.getAnnotationProcessors();
+            if (annotationProcessors != null && annotationProcessors.length > 0) {
                 args.add("-processor");
-                String[] procs = config.getAnnotationProcessors();
                 StringBuilder buffer = new StringBuilder();
-                for (int i = 0; i < procs.length; i++) {
+                for (int i = 0; i < annotationProcessors.length; i++) {
                     if (i > 0) {
                         buffer.append(",");
                     }
-                    buffer.append(procs[i]);
+                    buffer.append(annotationProcessors[i]);
                 }
                 args.add(buffer.toString());
             }

--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -371,31 +371,6 @@ public class JavacCompiler extends AbstractCompiler {
         return buildCompilerArguments(config, getSourceFiles(config), javacVersion);
     }
 
-    /**
-     * Joins the configured annotation processor names, skipping blank entries.
-     * <p>
-     * Maven maps an explicitly empty {@code <annotationProcessors/>} element to an array of blank
-     * strings rather than to an empty array, and passing those on produces {@code -processor} with
-     * an empty processor name, which javac cannot resolve.
-     *
-     * @param annotationProcessors the configured names, possibly {@code null}
-     * @return the non-blank names joined by commas, or an empty string if there are none
-     */
-    private static String joinAnnotationProcessors(String[] annotationProcessors) {
-        StringBuilder buffer = new StringBuilder();
-        if (annotationProcessors != null) {
-            for (String annotationProcessor : annotationProcessors) {
-                if (annotationProcessor != null && !annotationProcessor.trim().isEmpty()) {
-                    if (buffer.length() > 0) {
-                        buffer.append(",");
-                    }
-                    buffer.append(annotationProcessor);
-                }
-            }
-        }
-        return buffer.toString();
-    }
-
     public static String[] buildCompilerArguments(
             CompilerConfiguration config, String[] sourceFiles, String javacVersion) {
         List<String> args = new ArrayList<>();

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -38,6 +38,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author <a href="mailto:jason@plexus.org">Jason van Zyl</a>
@@ -198,6 +201,33 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
         String[] actualArguments = JavacCompiler.buildCompilerArguments(compilerConfiguration, sources, javacVersion);
 
         assertArrayEquals(actualArguments, expectedArguments.toArray(new String[0]));
+    }
+
+    @Test
+    public void testBuildCompilerArgsEmptyAnnotationProcessors() {
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+        compilerConfiguration.setOutputLocation("/output");
+        compilerConfiguration.setAnnotationProcessors(new String[0]);
+
+        String[] actualArguments = JavacCompiler.buildCompilerArguments(compilerConfiguration, new String[0], "17");
+
+        assertFalse(
+                Arrays.asList(actualArguments).contains("-processor"),
+                "an empty processor array must not produce -processor with an empty argument");
+    }
+
+    @Test
+    public void testBuildCompilerArgsAnnotationProcessors() {
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+        compilerConfiguration.setOutputLocation("/output");
+        compilerConfiguration.setAnnotationProcessors(new String[] {"com.example.First", "com.example.Second"});
+
+        List<String> actualArguments =
+                Arrays.asList(JavacCompiler.buildCompilerArguments(compilerConfiguration, new String[0], "17"));
+
+        int index = actualArguments.indexOf("-processor");
+        assertTrue(index >= 0, "-processor must be present for a non-empty processor array");
+        assertEquals("com.example.First,com.example.Second", actualArguments.get(index + 1));
     }
 
     @Test

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -217,6 +217,34 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
     }
 
     @Test
+    public void testBuildCompilerArgsBlankAnnotationProcessors() {
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+        compilerConfiguration.setOutputLocation("/output");
+        compilerConfiguration.setAnnotationProcessors(new String[] {"", ""});
+
+        String[] actualArguments = JavacCompiler.buildCompilerArguments(compilerConfiguration, new String[0], "17");
+
+        assertFalse(
+                Arrays.asList(actualArguments).contains("-processor"),
+                "an array of blank processor names must not produce -processor");
+    }
+
+    @Test
+    public void testBuildCompilerArgsMixedBlankAnnotationProcessors() {
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+        compilerConfiguration.setOutputLocation("/output");
+        compilerConfiguration.setAnnotationProcessors(
+                new String[] {"", "com.example.First", " ", "com.example.Second"});
+
+        List<String> actualArguments =
+                Arrays.asList(JavacCompiler.buildCompilerArguments(compilerConfiguration, new String[0], "17"));
+
+        int index = actualArguments.indexOf("-processor");
+        assertTrue(index >= 0, "-processor must be present when at least one name is not blank");
+        assertEquals("com.example.First,com.example.Second", actualArguments.get(index + 1));
+    }
+
+    @Test
     public void testBuildCompilerArgsAnnotationProcessors() {
         CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
         compilerConfiguration.setOutputLocation("/output");


### PR DESCRIPTION
`JavacCompiler` and `EclipseJavaCompiler` both decided whether to pass `-processor` from the array's length alone, so an array of blank names produced `-processor` followed by an empty or comma-only argument. Fixes #512.

Both now route the field through one `joinAnnotationProcessors` helper on `AbstractCompiler` and emit the option only when a name survives. A single shared rule is the point: two hand-rolled guards that agree today drift apart tomorrow, which is how the two compilers came to disagree in the first place.

Filtering rather than length-checking is deliberate. `{"", ""}` has length 2, so a length guard still emits `-processor ,`. It also mirrors the semantic that apache/maven-compiler-plugin#1077 just merged caller-side, so behaviour is the same whether or not a user's plugin version carries that fix.

## Compatibility

Every input whose behaviour changes — `{""}`, `{"", ""}`, `{"", "X"}` — previously made javac fail on an unresolvable processor name, so no working configuration depended on the old output.

One semantic worth stating: `-processor` suppresses javac's default `ServiceLoader` discovery, so omitting the option for an all-blank list restores discovery. That is the intended reading, since an empty element means "unspecified" rather than "none" — `<proc>none</proc>` remains the way to ask for no annotation processing, and it is an independent flag.

If reviewers would rather blanks were not dropped silently, a warn-level log line when the filter removes something would be a small follow-up.

Verified: `mvn -pl plexus-compilers/plexus-compiler-javac,plexus-compilers/plexus-compiler-eclipse -am test` → 129 and 17 tests, no failures. The `{"", ""}` case fails on master and passes here.

*This change was created with AI assistance.*
