### PR TITLE
Accept the 1.x spelling for the javac release version

### DIFF
--- a/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
+++ b/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java
@@ -348,6 +348,21 @@ public class JavacCompiler extends AbstractCompiler {
     }
 
     /**
+     * Maps the {@code 1.x} spelling that {@code -source} and {@code -target} accept onto the plain feature
+     * number, the only form {@code --release} takes: {@code 1.8} becomes {@code 8}. Any other value is
+     * passed through unchanged, so javac still reports releases it does not support.
+     *
+     * @param release the configured release version, never empty
+     * @return the value to pass to {@code --release}
+     */
+    static String toReleaseArgument(String release) {
+        if (release.length() == 3 && release.startsWith("1.") && release.charAt(2) >= '1' && release.charAt(2) <= '9') {
+            return release.substring(2);
+        }
+        return release;
+    }
+
+    /**
      *
      * @return {@code true} if the current context class loader has access to {@code javax.tools.ToolProvider}
      */
@@ -492,7 +507,7 @@ public class JavacCompiler extends AbstractCompiler {
 
         if (JavaVersion.JAVA_9.isOlderOrEqualTo(javacVersion) && !StringUtils.isEmpty(config.getReleaseVersion())) {
             args.add("--release");
-            args.add(config.getReleaseVersion());
+            args.add(toReleaseArgument(config.getReleaseVersion()));
         } else {
             // TODO: this could be much improved
             if (StringUtils.isEmpty(config.getTargetVersion())) {

--- a/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
+++ b/plexus-compilers/plexus-compiler-javac/src/test/java/org/codehaus/plexus/compiler/javac/AbstractJavacCompilerTest.java
@@ -478,6 +478,28 @@ public abstract class AbstractJavacCompilerTest extends AbstractCompilerTest {
     }
 
     @Test
+    public void testReleaseVersionInLegacySpelling() {
+        List<String> expectedArguments = new ArrayList<>();
+
+        CompilerConfiguration compilerConfiguration = new CompilerConfiguration();
+
+        // outputLocation
+        compilerConfiguration.setOutputLocation("/output");
+        expectedArguments.add("-d");
+        expectedArguments.add(new File("/output").getAbsolutePath());
+
+        // releaseVersion in the -source/-target spelling, which --release rejects
+        compilerConfiguration.setReleaseVersion("1.8");
+        expectedArguments.add("--release");
+        expectedArguments.add("8");
+
+        // unshared table
+        expectedArguments.add("-XDuseUnsharedTable=true");
+
+        internalTest(compilerConfiguration, expectedArguments, "11.0.1");
+    }
+
+    @Test
     public void testFailOnWarning() {
         List<String> expectedArguments = new ArrayList<>();
 


### PR DESCRIPTION
`-source` and `-target` accept both `8` and `1.8`, but `--release` only accepts `8`, and javac rejects the other form with `release version 1.8 not supported`. This maps `1.5` to `1.8` onto `5` to `8` when building the `--release` argument and passes every other value through unchanged. The Eclipse compiler adapter already does this for `1.9`.

This came out of apache/maven-apache-parent#608, where a parent deriving `maven.compiler.release` from a child's `maven.compiler.target` was considered; that parent change was dropped because maven-compiler-plugin 4.x cannot combine the properties, so this is a standalone convenience: a `release` written the way `target` has always been written works instead of failing.

Verified: `mvn verify -pl plexus-compilers/plexus-compiler-javac -am` → 140 tests in the javac module, 0 failures, including the new `testReleaseVersionInLegacySpelling`.

*This change was created with AI assistance.*
